### PR TITLE
Allow dynamic/evaluated names for images files.

### DIFF
--- a/src/modules/elements/DynamicImage.ts
+++ b/src/modules/elements/DynamicImage.ts
@@ -1,5 +1,5 @@
 
-import { ILayerElement, RenderContext2D } from "../interfaces";
+import { ILayerElement, IValuedElement, RenderContext2D } from "../interfaces";
 import { ParseState, Rectangle } from "../types";
 import Transformation from "./Transformation";
 import globalImageCache, { ImageDataType } from '../ImageCache'
@@ -7,7 +7,7 @@ import { evaluateStringValue } from "../../utils/helpers";
 
 // This class hold an image source (path) and associated data like processing options or transformation to apply.
 
-export default class DynamicImage implements ILayerElement
+export default class DynamicImage implements ILayerElement, IValuedElement
 {
     source: string = "";
     transform: Transformation | null = null;
@@ -29,17 +29,20 @@ export default class DynamicImage implements ILayerElement
             this.transform = new Transformation().loadFromActionData(state);
     }
 
+    // IValuedElement
+    // Sets/updates the image source.
+    setValue(value: string) {
+        this.source = evaluateStringValue(value.trim());
+    }
+
     loadFromActionData(state: ParseState): DynamicImage {
         let txParsed = false;
         for (let i = state.pos, e = state.data.length; i < e; ++i) {
             const dataType = state.data[i].id.split('image_').at(-1);  // last part of the data ID determines its meaning
             switch (dataType) {
-                case 'src': {
-                    const value = state.data[i].value.trim();
-                    if (value.length > 4)  // shortest possible valid image file name would be 5 chars.
-                        this.source = evaluateStringValue(value);
+                case 'src':
+                    this.setValue(state.data[i].value);
                     break;
-                }
                 case 'fit':
                     this.resizeOptions['fit'] = state.data[i].value;
                     break;

--- a/src/modules/elements/DynamicImage.ts
+++ b/src/modules/elements/DynamicImage.ts
@@ -3,6 +3,7 @@ import { ILayerElement, RenderContext2D } from "../interfaces";
 import { ParseState, Rectangle } from "../types";
 import Transformation from "./Transformation";
 import globalImageCache, { ImageDataType } from '../ImageCache'
+import { evaluateStringValue } from "../../utils/helpers";
 
 // This class hold an image source (path) and associated data like processing options or transformation to apply.
 
@@ -36,7 +37,7 @@ export default class DynamicImage implements ILayerElement
                 case 'src': {
                     const value = state.data[i].value.trim();
                     if (value.length > 4)  // shortest possible valid image file name would be 5 chars.
-                        this.source = value;
+                        this.source = evaluateStringValue(value);
                     break;
                 }
                 case 'fit':


### PR DESCRIPTION
Funny, forgot one the main reasons I wanted dynamic images to begin with... so the image file names can also be dynamic.

For example this is composing the LCD readout from images named 0-9 based on current numeric value of a variable. 


https://user-images.githubusercontent.com/1366615/208793062-27910c03-7cdd-4fde-8d6b-025a556cb9ed.mp4
