### PR TITLE
Use 'file' type input fields for image source (for TP v3.1b8+)

### DIFF
--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -350,7 +350,7 @@ function addImageAction(id, name, withTx = true) {
     let i = data.length;
     format += `Image\nFile {${i++}}Resize\nFit {${i++}}`;
     data.push(
-        makeActionData("image_src", "text", "Image Source"),
+        makeActionData("image_src", "file", "Image Source"),
         makeChoiceData("image_fit", "Resize Fit", ["contain", "cover", "fill", "scale-down", "none"]),
     );
     if (withTx) {


### PR DESCRIPTION
File input types work great now in latest Beta of 3.1b8, allowing both manual and dynamic value entry.  Sounds like that version will be released soon, so hopefully this isn't rushing things.