### PR TITLE
Add plugin setting to control default base image directory

### DIFF
--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -65,7 +65,15 @@ const entry_base =
             "default": "256",
             "minValue": 8,
             "maxValue": 1920, // arbitrary
-            "readOnly": false
+            "readOnly": false,
+            "description": "Image size produced when using standalone 'Draw' actions for producing icons, without any layering."
+        },
+        {
+            "name": "Default Image Files Path",
+            "type": "text",
+            "default": "",
+            "readOnly": false,
+            "description": "Base directory to use when loading image files specified using a relative path. When left empty, the default is Touch Portal's configuration directory for the current user."
         }
     ],
     "categories": [

--- a/src/modules/ImageCache.ts
+++ b/src/modules/ImageCache.ts
@@ -4,6 +4,7 @@ import { loadImage } from 'skia-canvas';
 import { Mutex } from 'async-mutex';
 import { SizeType } from './types';
 import { logIt } from '../common'
+import { isAbsolute as isAbsPath, join as pjoin } from 'path';
 
 /** Central storage for various image processing options; Set via ImageCache.cacheOptions
 Some of these could in theory be controlled via plugin settings or action data. */
@@ -12,6 +13,7 @@ class ImageCacheOptions {
     actual cache size may grow a bit above this level to optimize the buffer trimming operations.
     Reducing this value at runtime will only take effect next time an image is added to the cache. */
     maxCachedImages: number = 250;
+    baseImagePath: string = "";
     // See https://sharp.pixelplumbing.com/api-constructor#sharp
     sourceLoadOptions: any = { density: 72 };  // [dpi] only relevant for loading vector graphics. 72 is default;
     // See also https://sharp.pixelplumbing.com/api-resize#resize
@@ -134,6 +136,8 @@ export class ImageCache
      */
     public async getOrLoadImage(src: string, size: SizeType, resizeOptions:any = {}, meta?: any): Promise<ImageDataType>
     {
+        if (ImageCache.cacheOptions.baseImagePath && !isAbsPath(src))
+            src = pjoin(ImageCache.cacheOptions.baseImagePath, src);
         if (ImageCache.cacheOptions.maxCachedImages <= 0)
             return this.loadImage(src, size, resizeOptions);  // short-circuit for disabled cache
 


### PR DESCRIPTION
Having the plugin's install folder as the default base path was awkward and pretty useless. This changes the default image base path from the plugin's installed directory to TP's config directory, two levels up. Relative paths in any existing actions will need to be updated.

And the base path can now be set by the user with "Default Image Files Path" setting.

If there's a better cross-platform way to determine TP's config folder, I'm all for it. 
https://github.com/spdermn02/TouchPortal-Dynamic-Icons/pull/8/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R31