### PR TITLE
fix: :bug: Fixing name of icon that is built with plugin

### DIFF
--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -72,7 +72,7 @@ const entry_base =
         {
             "id": "TP Dynamic Icons",
             "name": "Dynamic Icons",
-            "imagepath": "%TP_PLUGIN_FOLDER%touchportal-dynamic-icons/tp-dynamic-icons.png",
+            "imagepath": "%TP_PLUGIN_FOLDER%touchportal-dynamic-icons/touchportal-dynamic-icons.png",
             "actions": [],
             "connectors": [],
             "states": [


### PR DESCRIPTION
Needed to use package name for plugin icon name