### PR TITLE
Change stroke line width action data fields to text type

### DIFF
--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -309,7 +309,7 @@ function makeDrawStyleData(idPrefix, /* out */ data, withShadow = true) {
     let format = `Fill\nColor{${i++}}Stroke\nWidth{${i++}}{${i++}}Stroke\nColor{${i++}}`;
     data.push(
         makeColorData(idPrefix +  "_style_fillColor", "Fill"),
-        makeNumericData(idPrefix + "_style_line_width", "Stroke Width", 0, 0, 999999, true),
+        makeTextData(idPrefix + "_style_line_width", "Stroke Width", "0"),
         makeSizeTypeData(idPrefix + "_style_line_width"),
         makeColorData(idPrefix +  "_style_line_color", "Stroke"),
     );


### PR DESCRIPTION
This allows TP variables and JS expressions for the values. Technically, as "promised" by my changelog notes on v1.2  (I forgot about the actual Action format being numeric).

This does make all the related actions that much wider... the new linear bar even has 2 of them. So maybe it's not worth it, I dunno... at least until we finally get multiline actions.

Personally I don't mind the extra width that much at this point... already have to scroll them so a few more pixels doesn't hurt.  But I can go either way on this.