### PR TITLE
Add plugin setting and per-icon option to set output image compression level

### DIFF
--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -83,6 +83,19 @@ const entry_base =
                 "GPU rendering is only supported on some hardware/OS/drivers, and is disabled on others regardless of this setting.\n\n" +
                 "Note that at least some CPU will be used when generating icons in any case, most notably for image file loading and final output PNG compression."
         },
+        {
+            "name": "Default Output Image Compression Level (0-9)",
+            "type": "text",
+            "default": "4",
+            "readOnly": false,
+            "description": "Sets or disables the default image compression level of generated icons. This can be set to a number between 1 (low compression) and 9 (high compression)," +
+                " or 0 (zero) to disable compression entirely.\n" +
+                "This option can be also be overridden per icon. Changing this setting does not affect any icons already generated since the plugin was started.\n\n" +
+                "Compression affects the final image data size which will be sent to the TP device for display. The higher the compression level, the smaller the final size." +
+                " However, compression uses CPU resources, proportional to the compression level (higher level means more CPU use) and may produce lower quality images.\n\n" +
+                "Large image data sizes may impact the performance of the connected TP device to the point that it becomes unusable due to the lag. " +
+                "This setting can be adjusted to fine-tune the impact of dynamic icon generation on your computer vs. efficient delivery of images to the TP device."
+        },
     ],
     "categories": [
         {
@@ -519,11 +532,12 @@ function addGenerateLayersAction(id, name) {
     const descript = "Dynamic Icons: " +
         "Finalize and/or Render a dynamic image icon which has been created using preceding 'New' and 'Draw/Layer' actions using the same Icon Name.\n" +
         "'Finalize' marks the icon as finished, removing any extra layers which may have been added previously. 'Render' produces the actual icon in its current state and sends it to TP.";
-    const format = "Icon Named {0} {1} | Enable GPU Rendering: {2} (default is set in plugin Settings)";
+    const format = "Icon Named {0} {1} | Enable GPU Rendering: {2} Compression Level: {3} (defaults are set in plugin Settings)";
     const data = [
         makeIconNameData(id),
         makeChoiceData("icon_generate_action", "Action", ["Finalize & Render", "Finalize Only", "Render Only"]),
         makeChoiceData("icon_generate_gpu", "Enable GPU Rendering", ["default", "Enable", "Disable"]),
+        makeChoiceData("icon_generate_cl", "Image Compression Level", ["default", "None", "1 (low)", "2", "3", "4", "5", "6", "7", "8", "9 (high)"]),
     ];
     addAction(id, name, descript, format, data);
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,5 +1,11 @@
 import { SizeType } from "./modules/geometry";
 
+export var TPClient: any = null;
+export function setTPClient(client: Object) {
+    TPClient = client;
+    logIt = (...args: any[]) => { TPClient.logIt(...args) };
+}
+
 // hackish way to share the TPClient "logger" with other modules
 export var logIt: Function = console.log;
 export function setCommonLogger(logger: Function) {

--- a/src/common.ts
+++ b/src/common.ts
@@ -11,4 +11,5 @@ export const PluginSettings = {
     // these can be changed in TP Settings
     defaultIconSize: <SizeType> { width: 256, height: 256 },
     defaultGpuRendering: <boolean> true,
+    defaultOutputCompressionLevel: <number> 4,  // MP: 4 seems to give the highest effective compression in my tests, no gains with higher levels but does slow down.
 };

--- a/src/modules/DynamicIcon.ts
+++ b/src/modules/DynamicIcon.ts
@@ -18,12 +18,19 @@ export default class DynamicIcon
     delayGeneration: boolean = false;
     /** Whether to use GPU for rendering (on supported hardware). Passed to skia-canvas's Canvas::gpu property. */
     gpuRendering: boolean = PluginSettings.defaultGpuRendering;
-    /** Whether to use additional output compression before sending image state data to TP. */
-    compressOutput: boolean = true;
     /** Used while building a icon from TP layer actions to keep track of current layer being affected. */
     nextIndex: number = 0;
     /** The array of elements which will be rendered. */
     layers: ILayerElement[] = [];
+    // Options for the 'sharp' lib image compression. These are passed to sharp() when generating PNG results.
+    // `compressionLevel` of `0` disables compression step entirely on non-tiled icons (sharp lib is never invoked);
+    // On tiled icons we're using sharp already to split up the tiles, so `0` forces the compression level of 1 because 0 makes huge files.
+    // See https://sharp.pixelplumbing.com/api-output#png for option descriptions.
+    outputCompressionOptions: any = {
+        compressionLevel: PluginSettings.defaultOutputCompressionLevel,
+        effort: 1,        // MP: 1 actually uses less CPU time than higher values (contrary to what sharp docs suggest) and gives slightly higher compression.
+        palette: true     // MP: Again the docs suggest enabling this would be slower but my tests show a significant speed improvement.
+    };
 
     constructor(init?: Partial<DynamicIcon>) { Object.assign(this, init); }
 

--- a/src/modules/DynamicIcon.ts
+++ b/src/modules/DynamicIcon.ts
@@ -52,7 +52,7 @@ export default class DynamicIcon
         return `${this.name} - Tile col. ${tile.x+1}, row ${tile.y+1}`
     }
 
-    // Send TP State update with an icon's image data. This is used for untiled images (most common scenario).
+    // Send TP State update with an icon's image data. The data Buffer is encoded to base64 before transmission.
     private sendStateData(stateId: string, data: Buffer | null) {
         if (data?.length) {
             // logIt("DEBUG", `Sending data for icon state '${stateId}' with length ${data.length}`);
@@ -102,6 +102,7 @@ export default class DynamicIcon
             for (let x=0; x < this.tile.x; ++x) {
                 try {
                     const tileCtx = new Canvas(w, h).getContext("2d");
+                    tileCtx.canvas.gpu = this.gpuRendering;
                     tileCtx.drawCanvas(canvas, x * w, y * h, w, h, 0, 0, w, h);
                     this.sendCanvasImage(this.getTileStateId({x: x, y: y}), tileCtx.canvas);
                 }


### PR DESCRIPTION
As per Discord discussion... allows tuning of CPU usage for compression vs. final image data size sent to device.

Disabling compression for non-tiled icons means skipping the `skia` load/output step entirely. Basically reverting to plugin v1.0 behavior.

As mentioned in comments and discussion, one limitation is that when producing tiled icons right now we can't skip the `sharp` step entirely (since it does the tile extractions), so "no compression" actually means "low compression" for tiled icons.

I do have an alternate idea for the tiling, using skia-canvas directly, but that will take some experimenting.

-Max