### PR TITLE
Add GH workflow for builds/releases

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,80 @@
+name: Build and release version as draft
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+
+  init:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      clean_vers: ${{ steps.set_version.outputs.clean_vers }}
+      tag_vers:  ${{ steps.lasttag.outputs.tag }}
+    steps:
+      - name: Get last version tag
+        id: lasttag
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: ${{ github.repository }}
+
+      - name: Set Version Strings
+        uses: actions/github-script@v4
+        id: set_version
+        with:
+          script: |
+            const clean_v = "${{ steps.lasttag.outputs.tag }}".replace('v', '')
+            core.setOutput('clean_vers', clean_v)
+
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.lasttag.outputs.tag }}
+          name: ${{ steps.lasttag.outputs.tag }} Release
+          draft: true
+          prerelease: true
+          allowUpdates: true
+          removeArtifacts: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+
+  build:
+    name: Build
+    needs: init
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, macos-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        run: |
+          mkdir ./Installers
+          npm install && npm run build -- -p ${{ runner.os }}
+
+      - name: Upload assets
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.init.outputs.upload_url }}
+          asset_path: ./Installers/touchportal-dynamic-icons-${{ runner.os }}-${{ needs.init.outputs.clean_vers }}.tpp
+          asset_name: touchportal-dynamic-icons-${{ runner.os }}-${{ needs.init.outputs.clean_vers }}.tpp
+          asset_content_type: application/zip

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -7,34 +7,42 @@ on:
 
 jobs:
 
-  init:
+  release:
     name: Create Release
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
-      clean_vers: ${{ steps.set_version.outputs.clean_vers }}
-      tag_vers:  ${{ steps.lasttag.outputs.tag }}
+      version:  ${{ steps.pckg_ver.outputs.version }}
     steps:
-      - name: Get last version tag
-        id: lasttag
-        uses: oprypin/find-latest-tag@v1
+      - name: Checkout package.json
+        uses: actions/checkout@v3
         with:
-          repository: ${{ github.repository }}
+          sparse-checkout: |
+            package.json
+          sparse-checkout-cone-mode: false
 
-      - name: Set Version Strings
-        uses: actions/github-script@v4
-        id: set_version
+      - name: "Get package version"
+        uses: actions/github-script@v6
+        id: pckg_ver
         with:
+          result-encoding: string
           script: |
-            const clean_v = "${{ steps.lasttag.outputs.tag }}".replace('v', '')
-            core.setOutput('clean_vers', clean_v)
+            try {
+              const pckgJson = require('./package.json')
+              const v = pckgJson.version
+              core.setOutput('version', v)
+              console.log("Package version is", v)
+            } catch(err) {
+              core.error("Error trying to read package.json")
+              core.setFailed(err)
+            }
 
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.lasttag.outputs.tag }}
-          name: ${{ steps.lasttag.outputs.tag }} Release
+          tag: v${{ steps.pckg_ver.outputs.version }}
+          name: v${{ steps.pckg_ver.outputs.version }} Release
           draft: true
           prerelease: true
           allowUpdates: true
@@ -46,7 +54,7 @@ jobs:
 
   build:
     name: Build
-    needs: init
+    needs: release
     strategy:
       fail-fast: false
       matrix:
@@ -60,13 +68,14 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+
+      - name: NPM install
+        run: |
+          npm install
+          mkdir ./Installers
 
       - name: Build
-        run: |
-          mkdir ./Installers
-          npm install && npm run build -- -p ${{ runner.os }}
+        run: npm run build -- -p ${{ runner.os }}
 
       - name: Upload assets
         id: upload-release-asset
@@ -74,7 +83,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.init.outputs.upload_url }}
-          asset_path: ./Installers/touchportal-dynamic-icons-${{ runner.os }}-${{ needs.init.outputs.clean_vers }}.tpp
-          asset_name: touchportal-dynamic-icons-${{ runner.os }}-${{ needs.init.outputs.clean_vers }}.tpp
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./Installers/touchportal-dynamic-icons-${{ runner.os }}-${{ needs.release.outputs.version }}.tpp
+          asset_name: touchportal-dynamic-icons-${{ runner.os }}-${{ needs.release.outputs.version }}.tpp
           asset_content_type: application/zip

--- a/builders/build.js
+++ b/builders/build.js
@@ -33,22 +33,22 @@ const build = async(platform, options ) => {
     let libvipsSrcPath = SHARP_BUILD
     let libvipsDestPath = `./base/${platform}/`
 
-    if (platform == "Windows" ) {
+    if (platform.toLowerCase() == "windows" ) {
         osTarget = "win"
         sharpPlatform = "win32"
         execName += ".exe"
         libvipsDestPath += `${SHARP_BUILD}/`
     }
-    else if (platform == "MacOS") {
+    else if (platform.toLowerCase() == "macos") {
         sharpPlatform = 'darwin'
     }
     // MacOS-Arm64 ?
-    else if (platform != "Linux") {
+    else if (platform.toLowerCase() != "linux") {
         console.error("Can't handle platform " + platform)
         exit(1)
     }
 
-    if (platform != "Windows" )  {
+    if (platform.toLowerCase() != "windows" )  {
         const vendorLibDir = fs.readdirSync(`${SHARP_ROOT}/vendor/`, { recursive: false, withFileTypes: false } ).filter(fn => /^\d+\.\d+\.\d+$/.test(fn)).at(-1)
         if (!vendorLibDir) {
             console.error("Could not locate sharp vendor lib version/directory in " + `${SHARP_ROOT}/vendor/`)
@@ -77,19 +77,19 @@ const build = async(platform, options ) => {
       ".",
     ]);
 
-    console.log("Running Zip File Creation")
+    let platform_arch = platform
+    if(options?.type)
+        platform_arch += `-${options.type}`
+    const packageName = path.normalize(`./Installers/${packageJson.name}-${platform_arch}-${packageJson.version}.tpp`)
+
+    console.log(`Creating zip file '${packageName}'`)
     const zip = new AdmZip()
     zip.addLocalFolder(
       path.normalize(`./base/${platform}/`),
       packageJson.name
     );
 
-    let packageName = `./Installers/${packageJson.name}-${platform}-${packageJson.version}.tpp`
-    if( options?.type !== undefined ) {
-      packageName = `./Installers/${packageJson.name}-${platform}-${options.type}-${packageJson.version}.tpp`
-    }
-
-    zip.writeZip(path.normalize(packageName))
+    zip.writeZip(packageName)
 
     console.log("Cleaning Up")
     fs.rmSync(`./base/${platform}`, { recursive : true})


### PR DESCRIPTION
First thing to mention is that cross-platform builds (still) aren't working. Due to skia-canvas, actually -- it needs platform-specific binaries.  There's probably some magic that can be cooked up, but I couldn't get npm/pkg to pull the correct binaries per build platform... they were always the ones for the host OS. Which doesn't work out.

This workflow will build all 3 OSs and push the resulting tpp files to a tagged Release as assets.
* It is set up to trigger whenever a "v*" tag is pushed which will then build/release that tag ref.
* It can also be triggered manually (once pushed to main branch), in which case it builds whichever branch it is run from.
* The version number for the release is read from the checked-out repo's package.json.
* A new draft pre-release is created for a version if one doesn't already exist. A matching tag is not created unless/until a draft release is actually published (or the tag can be created manually first).
* If a release already exists for the same version, all the binaries will be replaced but otherwise the release will be unchanged.

Tested the produced builds on Windows and Linux so far, no issues.  Some test builds/releases are on my fork, here: https://github.com/mpaperno/TouchPortal-Dynamic-Icons/releases
(The version numbers were just incremented as a test.)