### PR TITLE
Rectangular size icons

### DIFF
--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -15,8 +15,17 @@
 //
 
 const path = require("path");
-const { writeFileSync } = require("fs");
+const { writeFileSync, existsSync, statSync } = require("fs");
 const pkgConfig = require("../package.json");
+
+const COMMON_JS_PATH = "./dist/common.js";
+
+if (!existsSync(COMMON_JS_PATH) || statSync(COMMON_JS_PATH).mtimeMs < statSync("./src/common.ts").mtimeMs) {
+    console.error(COMMON_JS_PATH + " settings file not found or is older than source version, please run 'npm run tsc' first or 'npm run gen-entry'");
+    process.exit(1);
+}
+
+const { PluginSettings } = require("../" + COMMON_JS_PATH);
 
 // Defaults
 var VERSION = pkgConfig.version;
@@ -58,7 +67,7 @@ const entry_base =
         {
             "name": "Default Icon Size",
             "type": "number",
-            "default": "256",
+            "default": `${PluginSettings.defaultIconSize.width} x ${PluginSettings.defaultIconSize.height}`,
             "minValue": 8,
             "maxValue": 1920, // arbitrary
             "readOnly": false,
@@ -74,7 +83,7 @@ const entry_base =
         {
             "name": "Enable GPU Rendering by Default",
             "type": "text",
-            "default": "Yes",
+            "default": PluginSettings.defaultGpuRendering ? "Yes" : "No",
             "readOnly": false,
             "description": "Enables or disables using hardware acceleration (GPU), when available, for generating icon images. One of: \"yes, true, 1, or enable\" to enable, anything else to disable.\n" +
                 "This setting can be also be overridden per icon. Changing this setting does not affect any icons already generated since the plugin was started.\n\n" +
@@ -85,7 +94,7 @@ const entry_base =
         {
             "name": "Default Output Image Compression Level (0-9)",
             "type": "text",
-            "default": "4",
+            "default": PluginSettings.defaultOutputCompressionLevel.toString(),
             "readOnly": false,
             "description": "Sets or disables the default image compression level of generated icons. This can be set to a number between 1 (low compression) and 9 (high compression)," +
                 " or 0 (zero) to disable compression entirely.\n" +

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -500,14 +500,16 @@ function addProgressBarAction(id, name) {
 function addStartLayersAction(id, name) {
     const descript = "Dynamic Icons: " + name + "\n" +
         "Start a new Layered Icon. Add elements(s) in following 'Draw' and 'Layer' action(s) and then use the 'Generate' action to produce the icon.";
-    const format = "Icon Name {0} of size {1} (pixels square, each tile), tiled to {2} column(s) wide and {3} row(s) high.";
+    let [format, data] = makeIconLayerCommonData(id);
+    let i = data.length;
+    format += `of size {${i++}} wide by {${i++}} high (pixels), tiled to {${i++}} column(s) wide and {${i++}} row(s) high.`;
     const tileChoices = Array.from({length: 15}, (x, i) => (i+1).toString());  // ["1"..."15"]
-    const data = [
-        makeIconNameData(id),
-        makeActionData("icon_size", "text", "Icon Size", "256"),
+    data.push(
+        makeTextData("icon_size", "Icon Width", PluginSettings.defaultIconSize.width),
+        makeTextData("icon_size_h", "Icon Height", PluginSettings.defaultIconSize.height),
         makeChoiceData("icon_tile_x", "Tile Columns", tileChoices),
         makeChoiceData("icon_tile_y", "Tile Rows", tileChoices),
-    ];
+    );
     addAction(id, name, descript, format, data);
 }
 

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -66,10 +66,8 @@ const entry_base =
     "settings": [
         {
             "name": "Default Icon Size",
-            "type": "number",
+            "type": "text",
             "default": `${PluginSettings.defaultIconSize.width} x ${PluginSettings.defaultIconSize.height}`,
-            "minValue": 8,
-            "maxValue": 1920, // arbitrary
             "readOnly": false,
             "description": "Image size produced when using standalone 'Draw' actions for producing icons, without any layering."
         },
@@ -93,8 +91,10 @@ const entry_base =
         },
         {
             "name": "Default Output Image Compression Level (0-9)",
-            "type": "text",
+            "type": "number",
             "default": PluginSettings.defaultOutputCompressionLevel.toString(),
+            "minValue": 0,
+            "maxValue": 9,
             "readOnly": false,
             "description": "Sets or disables the default image compression level of generated icons. This can be set to a number between 1 (low compression) and 9 (high compression)," +
                 " or 0 (zero) to disable compression entirely.\n" +

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:watch": "nodemon --watch .eslintrc.js --exec \"npm run lint\"",
     "start": "ts-node ./src/index.ts",
     "start-dist": "tsc && pkg . && node ./dist/index.js",
-    "gen-entry": "node builders/gen_entry.js"
+    "gen-entry": "tsc && node builders/gen_entry.js"
   },
   "repository": {
     "type": "git",

--- a/src/common.ts
+++ b/src/common.ts
@@ -15,7 +15,7 @@ export function setCommonLogger(logger: Function) {
 // Runtime options.
 export const PluginSettings = {
     // these can be changed in TP Settings
-    defaultIconSize: <SizeType> { width: 256, height: 256 },
+    defaultIconSize: <SizeType> { width: 128, height: 128 },
     defaultGpuRendering: <boolean> true,
     defaultOutputCompressionLevel: <number> 4,  // MP: 4 seems to give the highest effective compression in my tests, no gains with higher levels but does slow down.
 };


### PR DESCRIPTION
These changes allow setting width and height independently.

The tiling behavior changes when using the _new_ "New Layered Icon" action with separate width and height -- The given width and height are split into tiles instead of each tile being the given size.

Preserves BC with earlier 1.2.0 alpha versions.

The first 2 commits aren't directly related -- the first one pulls settings from the code base for the entry generator, and the 2nd **changes the default icon size to 128px** (but will not change any current users' defaults).

This is _one, untiled_ rectangular icon displayed on a 4x1 button, with regular TP buttons underneath to show the page grid spacing. 

![image](https://github.com/spdermn02/TouchPortal-Dynamic-Icons/assets/1366615/4e6b9b71-7ae1-4a3e-b13e-2f9667829cd0)
