### PR TITLE
Pull release notes from changelog when creating new Release from 'build-release' workflow

### DIFF
--- a/.github/actions/get-release-notes/action.yml
+++ b/.github/actions/get-release-notes/action.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+name: 'Extract Release Notes'
+description: 'Extract release notes from a CHANGELOG file.'
+author: 'Maxim Paperno'
+branding:
+  icon: 'file-text'
+  color: 'white'
+inputs:
+  version_tag:
+    description:
+      'The version tag to look for, as it appears in headings (eg. "v1.2.3-beta2"), or "latest" (default) to get the latest notes.'
+    required: false
+    default: 'latest'
+  changelog_file:
+    description: 'The input path of the changelog file. Default: .`CHANGELOG.md`'
+    required: false
+    default: './CHANGELOG.md'
+  changelog_ascending:
+    description: 'Specify that the change log lists changes in ascending order, newest at end. Default is false, latest release at top.'
+    required: false
+    default: false
+  fallback_to_latest:
+    description: 'Fall back to getting the latest version release notes if a block which matches "version_tag" is not found. Default is false.'
+    required: false
+    default: false
+  output_file:
+    description: 'An optional file path/name to write the extracted title and release notes to.'
+    required: false
+    default: ''
+outputs:
+  release_title:
+    description: 'The full heading line with version number. The leading "## " will be stripped and the result trimmed.'
+  release_notes:
+    description: 'The release notes body for found version.'
+runs:
+  using: 'node16'
+  main: 'index.js'

--- a/.github/actions/get-release-notes/index.js
+++ b/.github/actions/get-release-notes/index.js
@@ -1,0 +1,137 @@
+
+const fs = require('fs')
+const readline = require('readline')
+
+module.exports = extractReleaseNotes;
+
+var core = null;
+if (process.env["GITHUB_ACTIONS"]) {
+    try { core = require('@actions/core'); }
+    catch(e) {
+        try {
+            require("child_process").execSync("npm install --no-audit --silent @actions/core")
+            core = require('@actions/core');
+        }
+        catch {
+            console.error("Couldn't load @actions/core!", e);
+            process.exit(1);
+        }
+    }
+}
+
+const DEBUG = true;
+
+const debug = function (...args) {
+    if (core)
+        core.debug(...args);
+    else if (DEBUG)
+        console.debug(...args);
+}
+
+async function extractReleaseNotes(changelog, tag, order_asc)
+{
+    const findLatest = tag == "latest",
+        vlineRegEx = /^## .*/,
+        tagRegEx = findLatest ? vlineRegEx : new RegExp("^## .*" + tag.replace(/[+.-]/g, '\\$&'));
+
+    let heading = "",
+        capture = false,
+        lines = [];
+
+    const rli = readline.createInterface({
+        input: fs.createReadStream(changelog, {encoding: 'utf8'})
+    });
+
+    for await (const line of rli) {
+        if (capture) {
+            if (!vlineRegEx.test(line)) {
+                lines.push(line);
+                continue;
+            }
+            if (!order_asc)
+                break;
+            capture = false;
+        }
+        if (tagRegEx.test(line)) {
+            heading = line.replace(/^## /, '').trim();
+            capture = true;
+            if (findLatest && order_asc)
+                lines = [];
+        }
+    }
+
+    return { heading: heading, releaseNotes: lines.join('\n').trim() };
+}
+
+function writeToFile(outfile, text) {
+    if (outfile == "-") {
+        console.log(text);
+        return;
+    }
+
+    debug(`writing output file: '${outfile}'`);
+    fs.writeFile(
+        outfile,
+        text,
+        { encoding: 'utf8' },
+        (err) => { if (err) throw err }
+    );
+}
+
+main().catch((err) => {
+    if (core)
+        core.setFailed(err.message);
+    else
+        console.error(err);
+})
+
+async function main()
+{
+    let tag = "latest",
+        changelog = "./CHANGELOG.md",
+        order_asc = false,
+        fallback = false,
+        output = "-";
+
+    if (core) {
+        tag = core.getInput('version_tag', {required: true});
+        changelog = core.getInput('changelog_file', {required: true});
+        order_asc = core.getBooleanInput('changelog_ascending');
+        fallback = core.getBooleanInput('fallback_to_latest');
+        output = core.getInput('output_file');
+    }
+    else {
+        // Handle CLI arguments
+        for (let i=2; i < process.argv.length; ++i) {
+            const arg = process.argv[i];
+            if      (arg == "-v") tag = process.argv[++i];
+            else if (arg == "-c") changelog = process.argv[++i];
+            else if (arg == "-o") output = process.argv[++i];
+            else if (arg == "-a") order_asc = true;
+            else if (arg == "-f") fallback = true;
+        }
+    }
+
+    debug(`<< version_tag = '${tag}'`);
+    debug(`<< changelog_file = '${changelog}'`);
+    debug(`<< changelog_ascending = '${order_asc}'`);
+    debug(`<< fallback_to_latest = '${fallback}'`);
+    debug(`<< output_file = '${output}'`);
+
+    let {heading, releaseNotes} = await extractReleaseNotes(changelog, tag, order_asc);
+    if (!heading && fallback && tag !== "latest") {
+        debug("Tagged release notes not found, falling back to latest version.");
+        ({heading, releaseNotes} = await extractReleaseNotes(changelog, "latest", order_asc));
+    }
+
+    debug(`>> release_title = '${heading}'`);
+    debug(`>> release_notes = '${releaseNotes}'`);
+
+    if (output)
+        writeToFile(output, heading + "\n\n" + releaseNotes);
+
+    if (core) {
+        core.setOutput("release_title", heading);
+        core.setOutput("release_notes", releaseNotes);
+    }
+}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -18,34 +18,55 @@ jobs:
         uses: actions/checkout@v3
         with:
           sparse-checkout: |
-            package.json
-          sparse-checkout-cone-mode: false
+            .github/actions
 
-      - name: "Get package version"
+      - name: "Get package version and check if release exists"
         uses: actions/github-script@v6
         id: pckg_ver
         with:
           result-encoding: string
           script: |
             try {
-              const pckgJson = require('./package.json')
-              const v = pckgJson.version
-              core.setOutput('version', v)
-              console.log("Package version is", v)
+              const pckgJson = require('./package.json');
+              const v = pckgJson.version;
+              core.setOutput('version', v);
+              console.log("Package version is", v);
+
+              const { owner, repo } = context.repo;
+              const tag = "v" + v;
+              let exists = false;
+              try {
+                const releases = await github.rest.repos.listReleases({ owner, repo });
+                exists = !!releases.data.find((r) => r.tag_name == tag );
+              }
+              catch { }
+              console.log("Release for tag", tag, "already exists:", exists);
+              core.setOutput('release_exists', exists);
             } catch(err) {
-              core.error("Error trying to read package.json")
               core.setFailed(err)
             }
+
+      - name: "Get release notes"
+        if: ${{ steps.pckg_ver.outputs.release_exists == 'false' }}
+        uses: ./.github/actions/get-release-notes
+        id: release_notes
+        with:
+          version_tag: ${{ steps.pckg_ver.outputs.version }}
+          changelog_ascending: true
+          fallback_to_latest: true
 
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
         with:
           tag: v${{ steps.pckg_ver.outputs.version }}
-          name: v${{ steps.pckg_ver.outputs.version }} Release
+          name: ${{ steps.release_notes.outputs.release_title }}
+          body: ${{ steps.release_notes.outputs.release_notes }}
           draft: true
           prerelease: true
           allowUpdates: true
+          updateOnlyUnreleased: true
+          skipIfReleaseExists: false
           removeArtifacts: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true


### PR DESCRIPTION
When a new Release is created by the workflow, this will look in CHANGELOG.md for a block with a matching tag header (eg `## v1.2.0-alpha3 ...`) and pull that block into the Release text. If no exact tag match is found it will pull in the latest changes (eg. perhaps still with "unreleased" or "next version" tag).

It will not modify existing Releases, or even bother getting the release notes if that's the case.