### PR TITLE
Logging!  RFC

### DIFF
--- a/base/plugin-config.json
+++ b/base/plugin-config.json
@@ -1,0 +1,20 @@
+{
+    "logging": {
+        "modules": {
+            ""         : "INFO",
+            "plugin"   : "INFO",
+            "icon"     : "INFO",
+            "imgcache" : "INFO",
+            "logging"  : "WARNING"
+        },
+        "endpoints": {
+            "Console": { "minLevel": "NONE" },
+            "File": {
+                "minLevel": "ANY",
+                "file": "./dynamic-icons-log.txt",
+                "maxSize": 20,
+                "keep": 10
+            }
+        }
+    }
+}

--- a/base/start.sh
+++ b/base/start.sh
@@ -23,6 +23,5 @@ then
 	sleep 1
 fi
 
-# this will output all Plugin log data to the TouchPortal/plugins/<prog> directory
-# in a file called <prog>log.txt instead of being captured inside the Touch Portal Logs
-./$prog > ${prog}_log.txt 2>&1 &
+# start the plugin
+./$prog

--- a/builders/build.js
+++ b/builders/build.js
@@ -26,6 +26,7 @@ const build = async(platform, options ) => {
     }
     fs.mkdirSync(`./base/${platform}`)
     fs.copyFileSync("./base/plugin_icon.png", `./base/${platform}/${packageJson.name}.png`)
+    fs.copyFileSync("./base/plugin-config.json", `./base/${platform}/plugin-config.json`)
 
     let osTarget = platform.toLowerCase()
     let sharpPlatform = osTarget
@@ -66,7 +67,7 @@ const build = async(platform, options ) => {
     copyFileSync(`${SHARP_BUILD}/sharp-${sharpPlatform}-x64.node`, `./base/${platform}/${SHARP_BUILD}/`)
 
     console.log("Generating entry.tp")
-    execSync(`node ./builders/gen_entry.js -v ${packageJson.version} -o ./base/${platform}`)
+    execSync(`node ./builders/gen_entry.js -o ./base/${platform}`)
 
     console.log("Running pkg")
     await pkg.exec([

--- a/src/common.ts
+++ b/src/common.ts
@@ -3,13 +3,6 @@ import { SizeType } from "./modules/geometry";
 export var TPClient: any = null;
 export function setTPClient(client: Object) {
     TPClient = client;
-    logIt = (...args: any[]) => { TPClient.logIt(...args) };
-}
-
-// hackish way to share the TPClient "logger" with other modules
-export var logIt: Function = console.log;
-export function setCommonLogger(logger: Function) {
-    logIt = logger;
 }
 
 // Runtime options.

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,19 @@ function createOrRemoveIconStates(icon: DynamicIcon, newTiles: PointType) {
     }
 }
 
+// Deletes icon(s) specified in `iconNames` array.
+function removeIcons(iconNames: string[], removeStates = true) {
+    iconNames.forEach((n) => {
+        const icon: DynamicIcon | undefined = g_dyanmicIconStates.get(n);
+        if (icon) {
+            if (removeStates)
+                createOrRemoveIconStates(icon, Point.new());
+            g_globalImageCache().clearIconName(icon.name);
+            g_dyanmicIconStates.delete(n);
+        }
+    });
+}
+
 
 // -------------------------------
 // Action handlers
@@ -129,21 +142,13 @@ function handleControlAction(actionId: string, data: TpActionDataArrayType) {
     switch (data[0].value) {
         case 'Clear the Source Image Cache':
             if (iconName == "All")
-                g_globalImageCache.clear();
+                g_globalImageCache().clear();
             else
-                g_globalImageCache.clearIconName(iconName);
+                g_globalImageCache().clearIconName(iconName);
             return
 
         case 'Delete Icon State': {
-            const iList = (iconName == "All" ? [...g_dyanmicIconStates.keys()] : [iconName]);
-            iList.forEach((n) => {
-                const icon: DynamicIcon | undefined = g_dyanmicIconStates.get(n);
-                if (icon) {
-                    createOrRemoveIconStates(icon, Point.new());
-                    g_globalImageCache.clearIconName(icon.name);
-                    g_dyanmicIconStates.delete(n);
-                }
-            });
+            removeIcons(iconName == "All" ? [...g_dyanmicIconStates.keys()] : [iconName]);
             sendIconLists();
             return;
         }

--- a/src/modules/elements/DynamicImage.ts
+++ b/src/modules/elements/DynamicImage.ts
@@ -77,7 +77,7 @@ export default class DynamicImage implements ILayerElement, IValuedElement
         if (!ctx || this.isEmpty)
             return;
 
-        const img: ImageDataType = await globalImageCache.getOrLoadImage(this.source, rect.size, this.resizeOptions, { iconName: this.iconName });
+        const img: ImageDataType = await globalImageCache().getOrLoadImage(this.source, rect.size, this.resizeOptions, { iconName: this.iconName });
         if (!img)
             return;
         // check if any transformation steps are needed, otherwise just draw the image directly

--- a/src/modules/logging/ConsoleEndpoint.ts
+++ b/src/modules/logging/ConsoleEndpoint.ts
@@ -1,0 +1,41 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+import { ConsoleFormatter, IEndpointOptions } from "./";
+import StreamEndpoint from './StreamEndpoint'
+
+var instance: ConsoleEndpointImpl | null = null;
+
+// Only one console output can exist per application so the actual implementation class
+// is hidden behind a Proxy (below). Thus we implement the singleton pattern.
+class ConsoleEndpointImpl extends StreamEndpoint
+{
+    readonly name: string = "Console";
+    constructor(options?: IEndpointOptions) {
+        if (!options)
+            options = {};
+        if (!options.formatter)
+            options.formatter = new ConsoleFormatter();
+        super(process.stdout, process.stderr, options);
+    }
+
+    get uid(): string { return "ConsoleEndpoint()"; }
+
+    static instance(): ConsoleEndpointImpl {
+        if (!instance)
+            instance = new ConsoleEndpointImpl();
+        return instance;
+    }
+}
+
+// Proxy the implementation's constructor to ensure only one instance ever exists.
+const ConsoleEndpoint = new Proxy(ConsoleEndpointImpl, {
+    construct(target, args) {
+        if (!instance)
+            instance = new target(...args);
+        return instance;
+    }
+});
+export default ConsoleEndpoint;

--- a/src/modules/logging/ConsoleFormatter.ts
+++ b/src/modules/logging/ConsoleFormatter.ts
@@ -1,0 +1,52 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+import { ILogEntry, ILogFormatter } from ".";
+import { formatTimeLocal as formatDate } from "./utils";
+// import ac from 'ansi-colors';
+
+// graphical log level indicators in place of text labels
+const LogLevelIcon = [
+    " ",    // ALL
+    "🟣",   // TRC
+    "🔵",   // DBG
+    "🟢",   // INF
+    "🟡",   // WRN
+    "🟠",   // ERR
+    "🔴",   // CRT
+    " ",    // NUL
+];
+
+// terminal color codes for wrapping various parts of the log message
+// https://en.m.wikipedia.org/wiki/ANSI_escape_code#Colors
+const Theme = {
+    timestamp: 95,   // bright magenta
+    module:    96,   // bright cyan
+    location:  37,   // white
+}
+
+const ansiColor = (code: number, str: string): string => { return `\x1b[${code}m${str}\x1b[39m` }
+
+// LVL TIMESTAMP    MODULE              MESSAGE                               LOCATION (if any)
+// 🔵 01:39:18.92 [imgcache] Image cache miss for nav_hdg_bug.svg; ...  [@ modules\ImageCache.ts:156:29]
+export default class ConsoleFormatter implements ILogFormatter
+{
+    format(entry: ILogEntry): string
+    {
+        return (
+            `${
+                LogLevelIcon[entry.level]
+            } ${
+                ansiColor(Theme.timestamp, formatDate(entry.timestamp))
+            } [${
+                ansiColor(Theme.module, entry.module)
+            }] ${
+                entry.message
+            }${
+                entry.location ? ansiColor(Theme.location, '  [@ ' + entry.location + ']') : ''
+            }`
+        );
+    }
+}

--- a/src/modules/logging/DefaultFormatter.ts
+++ b/src/modules/logging/DefaultFormatter.ts
@@ -1,0 +1,47 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+import { ILogEntry, ILogFormatter, LogLevelName3 } from ".";
+import { formatDateTimeLocal as formatDate } from "./utils";
+import { format } from 'util';
+
+//    TIMESTAMP       LVL    MODULE              MESSAGE                               LOCATION (if any)
+// 08-22 01:39:18.92 [DBG] [imgcache] Image cache miss for nav_hdg_bug.svg; ...  [@ modules\ImageCache.ts:156:29]
+export default class DefaultFormatter implements ILogFormatter
+{
+    format(entry: ILogEntry): string
+    {
+        return (
+            `${
+                formatDate(entry.timestamp)
+            } [${
+                LogLevelName3[entry.level]
+            }] {${
+                entry.module
+            }} ${
+                entry.message
+            }${
+                entry.location ? '  [@ ' + entry.location + ']' : ''
+            }`
+        );
+    }
+}
+
+/** Same as default formatter but first formats the message body and any args using Node's util.format().
+    This is what the Console class writer (used in StreamEndpoint and subclasses) already does so it's not necessary
+    for those endpoints, but may be for others endpoints types.
+    The current args array of the log entry, if any, is cleared after being used in the format() call.
+ */
+export class MessagePreFormatter extends DefaultFormatter
+{
+    format(entry: ILogEntry): string
+    {
+        if (entry.args && entry.args.length) {
+            entry.message = format.apply(null, [entry.message, ...entry.args]);
+            entry.args = undefined;
+        }
+        return super.format(entry);
+    }
+}

--- a/src/modules/logging/FileEndpoint.ts
+++ b/src/modules/logging/FileEndpoint.ts
@@ -1,0 +1,158 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+import { createWriteStream, WriteStream, renameSync } from 'fs';
+import { stat as fstat, readdir as readdirAsync, rm as rmAsync } from 'fs/promises';
+import { resolve as presolve, parse as pparse, join as pjoin } from 'path';
+import StreamEndpoint from './StreamEndpoint'
+import { IEndpointOptions } from './';
+import { formatDateTimeFileStamp } from './utils';
+
+/** Configuration settings for all instances of FileEndpoint. */
+export const FileEndpointConfig = {
+    /** Default base path for relative log file specs. */
+    BasePath: !!process["pkg"] ? require('path').dirname(process.execPath) : process.cwd()
+}
+
+/** Settings per instance of the endpoint, extends the generic `IEndpointOptions`. */
+export interface FileEndpointOptions extends IEndpointOptions {
+    file: string;     // path/name of log file
+    maxSize: number;  // max file size in MB
+    keep: number;     // # of old logs to keep
+}
+
+export default class FileEndpoint extends StreamEndpoint
+{
+    readonly name: string = "File";
+
+    private file: string = "";
+    private stream: WriteStream | null = null;
+    private maxSize: number = 20;  // MB
+    private keep: number = 7;
+    private fileCheckTimer: NodeJS.Timeout | null = null;
+
+    constructor(options?: FileEndpointOptions) {
+        super();
+        this.options = options;
+    }
+
+    get uid(): string { return `FileEndpoint(${this.file})`; }
+
+    get options(): FileEndpointOptions | any {
+        return Object.assign(super.options, {
+            file: this.file,
+            maxSize: this.maxSize / 1024 / 1024,
+            keep: this.keep
+        });
+    }
+    set options(options: FileEndpointOptions | any)
+    {
+        if (!options)
+            return;
+        if (typeof options.maxSize == "number" && options.maxSize > 0)
+            this.maxSize = options.maxSize * 1024 * 1024;
+        if (typeof options.keep == "number")
+            this.keep = options.keep;
+
+        // save minLevel and formatter options
+        super.options = options;
+
+        if (options.file !== undefined) {
+            const resolvFile = options.file ? presolve(FileEndpointConfig.BasePath, options.file) : "";
+            if (resolvFile != this.file) {
+                this.file = resolvFile;
+                this.closeFile();
+                if (resolvFile)
+                    this.openFile();
+            }
+        }
+    }
+
+    write(chunk: any, ...args: any[]) {
+        if (this.stream)
+            this.stream.write(chunk, ...args);
+    }
+
+    private openFile()
+    {
+        try {
+            this.stream = createWriteStream(this.file, { flags: 'a', encoding: 'utf8' });
+            super.options = { outStream: this.stream };
+            this.stream.on('close', () => { this.closeFile(); });
+
+            if (!this.fileCheckTimer) {
+                this.fileCheckTimer = setInterval(() => this.checkFileRotation(), 600000);
+                this.fileCheckTimer.unref();
+            }
+        }
+        catch(e: any) {
+            this.logger.error("Could not open %s file for writing with error: %s", this.file, e);
+            this.stream = null;
+        }
+    }
+
+    private closeFile()
+    {
+        if (!this.stream)
+            return;
+
+        if (this.outStream)
+            super.options = { outStream: null };
+        if (!this.stream.closed) {
+            try { this.stream.close(); }
+            catch(e: any) { this.logger.error("Error closing file: %s", e); }
+        }
+        this.stream = null;
+        if (this.fileCheckTimer)
+            clearInterval(this.fileCheckTimer);
+        this.fileCheckTimer = null;
+    }
+
+    private async checkFileRotation()
+    {
+        if (!this.stream)
+            return;
+        const size = (await fstat(this.file)).size;
+        if (size && size >= this.maxSize)
+            this.rotate();
+    }
+
+    private rotate()
+    {
+        if (!this.stream)
+            return;
+        const parse = pparse(this.file);
+        const newName = `${parse.name}_${formatDateTimeFileStamp(new Date())}${parse.ext}`;
+        this.closeFile();
+        try {
+            renameSync(this.file, presolve(parse.dir, newName));
+        }
+        catch(e) {
+            this.logger?.error("Failed to rename current log file %s with error: %s", this.file, e);
+        }
+        this.openFile();
+        this.logger.info("Log file rotation completed for '%s'; Old log saved as '%s'", parse.base, newName);
+        this.cleanOldLogs();
+    }
+
+    private async cleanOldLogs()
+    {
+        let count = 0;
+        const parse = pparse(this.file);
+        try {
+            const files = await readdirAsync(parse.dir);
+            for (const file of files) {
+                if (file.startsWith(parse.name) && ++count > this.keep) {
+                    rmAsync(pjoin(parse.dir, file), { force: true });
+                    this.logger.info("Removing old log file %s", file);
+                }
+            }
+        }
+        catch(e) {
+            this.logger.error("Failed to get listing for log dir '%s' with error: %s", parse.dir, e);
+        }
+    }
+
+}

--- a/src/modules/logging/LogLevel.ts
+++ b/src/modules/logging/LogLevel.ts
@@ -1,0 +1,65 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+
+/** Logging severity levels. */
+export const enum LogLevel {
+    ANY,        // log all levels
+    TRACE,
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR,
+    CRITICAL,   // throws Error exception after logging
+    NONE,       // suppress logging, eg. for an endpoint
+}
+
+/** Reverse lookup eg. for parsing json config. */
+export const LogLevelValue = {
+    "ANY"      : LogLevel.ANY,
+    "TRACE"    : LogLevel.TRACE,
+    "DEBUG"    : LogLevel.DEBUG,
+    "INFO"     : LogLevel.INFO,
+    "WARNING"  : LogLevel.WARNING,
+    "ERROR"    : LogLevel.ERROR,
+    "CRITICAL" : LogLevel.CRITICAL,
+    "NONE"     : LogLevel.NONE,
+}
+
+/** Full name indexed by value */
+export const LogLevelName = [
+    "ANY",
+    "TRACE",
+    "DEBUG",
+    "INFO",
+    "WARNING",
+    "ERROR",
+    "CRITICAL",
+    "NONE",
+];
+
+/** Shorter name (max. 5 chars) indexed by value. */
+export const LogLevelNameShort = [
+    "ANY",
+    "TRACE",
+    "DEBUG",
+    "INFO",
+    "WARN",
+    "ERROR",
+    "CRIT",
+    "NONE",
+];
+
+/** Abbreviated 3-character name indexed by value. */
+export const LogLevelName3 = [
+    "ANY",
+    "TRC",
+    "DBG",
+    "INF",
+    "WRN",
+    "ERR",
+    "CRT",
+    "NUL",
+];

--- a/src/modules/logging/LogManager.ts
+++ b/src/modules/logging/LogManager.ts
@@ -1,0 +1,223 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+    Inspired by Adrian Hall @ https://adrianhall.github.io/cloud/2019/06/30/building-an-efficient-logger-in-typescript/
+*/
+
+import { EventEmitter } from 'events';
+import { ILogOptions, ILogEndpoint, LogLevel, LogLevelName, LogLevelValue } from './';
+import Logger from './Logger'
+//@ts-ignore
+const endpointTypes = require('./endpoints');  // used in dynamic eval, TSC optimizes this out if it's an import
+
+var instance: LogManager | null = null;
+
+/** LogManager is a singleton and cannot be created directly. Use the exported `logging()` function. */
+class LogManager extends EventEmitter
+{
+    private options: ILogOptions = {
+        modules: {
+            '': LogLevel.INFO
+        },
+        endpoints: {}
+    };
+
+    private loggers: Map<string, Logger> = new Map();
+    private endpoints: Map<string, ILogEndpoint> = new Map();
+    private logger: Logger;
+
+    constructor() {
+        super();
+        this.logger = this.getLogger('logging');
+    }
+
+    get configuration(): ILogOptions { return Object.assign({}, this.options); }
+    get haveEndpoints(): boolean { return this.endpoints.size > 0; }
+
+    static instance(): LogManager {
+        if (!instance)
+            instance = new LogManager();
+        return instance;
+    }
+
+    haveEndpointId(idStartsWith: string): boolean {
+        for (const key of this.endpoints.keys())
+            if (key.startsWith(idStartsWith))
+                return true;
+        return false;
+    }
+
+    haveEndpointName(name: string): boolean {
+        for (const ep of this.endpoints.values())
+            if (ep.name == name)
+                return true;
+        return false;
+    }
+
+    getEndpointById(idStartsWith: string): ILogEndpoint | null {
+        for (const [key, value] of this.endpoints)
+            if (key.startsWith(idStartsWith))
+                return value;
+        return null;
+    }
+
+    /** Loads configuration from a JSON file's `logging` member object, if any.
+     * JSON parsing errors are reported, but a file missing entirely or not having a valid `logging` object at all is ignored. */
+    configureFromFile(file: string): LogManager
+    {
+        if (!require('fs').existsSync(file))
+            return this;
+
+        let jscfg: any = {};
+        try {
+            jscfg = require(file).logging;
+            if (typeof jscfg != "object")
+                return this;
+        }
+        catch(e) {
+            this.logError("Error logging configuration file'" + file + "': %s", e);
+            return this;
+        }
+
+        return this.configureFromJsonOrigin(jscfg);
+    }
+
+    /** Parses an `ILogOptions` object which was originally in JSON and converts the LogLevel enum names to actual enums.
+     * Then calls `configure()` with the modified options object. */
+    configureFromJsonOrigin(jsonConfig: any): LogManager
+    {
+        let gotConfig: boolean = false;
+        if (jsonConfig.modules) {
+            for (const [key, value] of Object.entries(jsonConfig.modules)) {
+                const ll: LogLevel | undefined = LogLevelValue[(value as string).toUpperCase()];
+                if (ll != undefined) {
+                    jsonConfig.modules[key] = ll;
+                    gotConfig = true;
+                }
+            }
+        }
+        if (jsonConfig.endpoints) {
+            for (const [key, value] of Object.entries(jsonConfig.endpoints)) {
+                if (!value || !(value as any).minLevel)
+                    continue;
+                const ll: LogLevel | undefined = LogLevelValue[(value as any).minLevel.toUpperCase()];
+                if (ll != undefined)
+                    jsonConfig.endpoints[key].minLevel = ll;
+            }
+            gotConfig = true;
+        }
+
+        return gotConfig ? this.configure(jsonConfig) : this;
+    }
+
+    /** Reads configuation options to set minimum module levels and create/register any specified endpoints.
+     * Endpoints in the config are specified by their `name`, eg "Console" or "File", and the corresponding classes must be called `${name}Endpoint`,
+     * eg. `ConsoleEndpoint` or `FileEndpoint`, and be exported in `./endpoints.ts`.  */
+    configure(options: ILogOptions): LogManager
+    {
+        this.options = Object.assign({}, this.options, options);
+
+        if (this.options.endpoints) {
+            for (const [key, value] of Object.entries(this.options.endpoints)) {
+                // don't add disabled endpoints
+                if (value && value.minLevel == LogLevel.NONE)
+                    continue;
+                try {
+                    const ep = eval(`new endpointTypes.${key}Endpoint()`);
+                    if (ep) {
+                        ep.options = value;
+                        this.registerEndpoint(ep);
+                    }
+                }
+                catch(e: any) {
+                    this.logError("Could not load endpoint '%s' with error: %s\n", key, e, e.stack);
+                }
+            }
+        }
+        return this;
+    }
+
+    /** Adds an endpoint as an output for log messages and configures it based on options found in the current logging configuration (if any).
+     * If an endpoint with the same `uid` already exists then it only modifies its configuratin but will not add another instance. */
+    registerEndpoint(endpoint: ILogEndpoint): LogManager
+    {
+        // check if we already have this endpoint
+        let ep: ILogEndpoint | undefined = this.findEndpoint(endpoint.uid);
+        const found: boolean = !!ep;
+        if (!ep)
+            ep = endpoint;
+
+        // check if we have a config for this endpoint
+        if (ep.options.minLevel == LogLevel.ANY && this.options.endpoints) {
+            const epcfg = this.options.endpoints[ep.name];
+            if (epcfg)
+                ep.options = epcfg;
+        }
+        // nothing else to do if we already had it
+        if (found)
+            return this;
+        // otherwise add to our list and register the event callback.
+        this.endpoints.set(ep.uid, ep);
+        return this.on("log", (le) => endpoint?.logEntry(le) );
+    }
+
+    /** Returns a `Logger` instance for the given `module` name. If a logger for this module already exists then it is returned, otherwise a new instance is created.
+     * If the optional `minLevel` is passed in, it will override any level set via other methods like in the initial logging configuration. */
+    getLogger(module: string, minLevel?: LogLevel): Logger
+    {
+        let logger = this.findLogger(module);
+        if (logger) {
+            if (minLevel != undefined)
+                logger.minLevel = minLevel;
+            return logger;
+        }
+
+        if (minLevel == undefined)
+            minLevel = this.findClosestModuleMatch(module);
+
+        this.logger?.debug("Adding logger %s with level %d", module, LogLevelName[minLevel]);
+
+        logger = new Logger(this, module, minLevel);
+        this.loggers.set(module, logger);
+        return logger;
+    }
+
+    /** Signals all endpoints to shut down. */
+    close()
+    {
+        for (const ep of this.endpoints.values())
+            ep.close();
+    }
+
+    private findLogger(module: string): Logger | undefined {
+        return this.loggers.get(module);
+    }
+
+    private findEndpoint(id: string): ILogEndpoint | undefined {
+        return this.endpoints.get(id);
+    }
+
+    private findClosestModuleMatch(module: string): LogLevel
+    {
+        let minLevel: LogLevel = LogLevel.NONE;
+        let match = '';
+        for (const [key, value] of Object.entries(this.options.modules)) {
+            if (module.startsWith(key) && key.length >= match.length) {
+                minLevel = value;
+                match = key;
+            }
+        }
+        return minLevel;
+    }
+
+    private logError(message:any, ...args: any[]) {
+        if (this.logger && this.haveEndpoints)
+            this.logger.error(message, ...args);
+        else
+            console.error(message, ...args);
+    }
+}
+
+const logging = LogManager.instance;
+export default logging;

--- a/src/modules/logging/Logger.ts
+++ b/src/modules/logging/Logger.ts
@@ -1,0 +1,87 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+import { EventEmitter } from 'events';
+import { ILogEntry, LogLevel } from './';
+import { format as nodeFormat } from 'util';
+
+// used for shortening source file paths when reporting caller location.  hackish.
+const sourceRootPath = require('path').normalize(__dirname + "/../../");
+
+/** Use `logging.getLogger()` method (from `LogManager`) to get a new instance of a Logger. */
+export default class Logger
+{
+    /** The module name this Logger is for. */
+    module: string;
+    /** The minimum severity level of messages this logger will output. */
+    minLevel: LogLevel;
+
+    /**
+     * Main logging method.
+     * @param logLevel Message severity.
+     * @param message Message body.
+     * @param ...args Additional formatting substitution values (like console.log(), et. al.).
+     */
+    log(logLevel: LogLevel, message: any, ...args: any[]): void { this.log_impl(logLevel, message, ...args); }
+    /** Convenience for `log(LogLevel.TRACE, message, ...args)` */
+    trace(message: any, ...args: any[]): void    { this.log_impl(LogLevel.TRACE, message, ...args); }
+    /** Convenience for `log(LogLevel.DEBUG, message, ...args)` */
+    debug(message: any, ...args: any[]): void    { this.log_impl(LogLevel.DEBUG, message, ...args); }
+    /** Convenience for `log(LogLevel.INFO, message, ...args)` */
+    info(message: any, ...args: any[]): void     { this.log_impl(LogLevel.INFO, message, ...args); }
+    /** Convenience for `log(LogLevel.WARNING, message, ...args)` */
+    warn(message: any, ...args: any[]): void     { this.log_impl(LogLevel.WARNING, message, ...args); }
+    /** Convenience for `log(LogLevel.ERROR, message, ...args)` */
+    error(message: any, ...args: any[]): void    { this.log_impl(LogLevel.ERROR, message, ...args); }
+    /** Convenience for `log(LogLevel.CRITICAL, message, ...args)`.
+     * After logging the message, it also throws an `Error` type exception with the same message
+     * and the location of the original call to `critical()` as the error's `cause` property. */
+    critical(message: any, ...args: any[]): void { this.log_impl(LogLevel.CRITICAL, message, ...args); }
+
+    /////////////
+
+    private logManager: EventEmitter;
+
+    /** Typically you would not construct a Logger directly but instead use `logging().getLogger()` or `LogManager.instance().getLogger()`. */
+    constructor(logManager: EventEmitter, module: string, minLevel: LogLevel) {
+        this.logManager = logManager;
+        this.module = module;
+        this.minLevel = minLevel;
+    }
+
+    private async log_impl(logLevel: LogLevel, message: any, ...args: any[]): Promise<void>
+    {
+        if (logLevel < this.minLevel)
+            return;
+
+        const logEntry: ILogEntry = {
+            level: logLevel,
+            timestamp: new Date(),
+            module: this.module,
+            message: message,
+            args: args.length ? Array.from(args) : undefined,
+        };
+
+        // This creates a new stack trace and pulls the caller from it.
+        if (logLevel < LogLevel.INFO) {
+            const error:any = {};
+            // The stack trace will start at the function _before_ this one. Since all the public log functions
+            // are proxies for this one, we know they're the next ones up the stack and the one before that will be the caller.
+            Error.captureStackTrace(error, this.log_impl);
+            // console.dir(error.stack);
+            if (error.stack) {
+                const sla = error.stack.split("\n", 4);
+                // The first line is "Error:" and the 2nd is the log method that was actually called, so we want the 3rd array member.
+                if (sla.length > 2)
+                    logEntry.location = sla[2].replace("at " + sourceRootPath, '').trim();
+            }
+        }
+
+        this.logManager.emit('log', logEntry);
+        if (logLevel == LogLevel.CRITICAL)
+            throw new Error(nodeFormat(message, ...args), { cause: logEntry.location });
+    }
+
+}

--- a/src/modules/logging/Logger.ts
+++ b/src/modules/logging/Logger.ts
@@ -75,7 +75,7 @@ export default class Logger
                 const sla = error.stack.split("\n", 4);
                 // The first line is "Error:" and the 2nd is the log method that was actually called, so we want the 3rd array member.
                 if (sla.length > 2)
-                    logEntry.location = sla[2].replace("at " + sourceRootPath, '').trim();
+                    logEntry.location = sla[2].slice(sla[2].indexOf("at ") + 3).replace(sourceRootPath, '');
             }
         }
 

--- a/src/modules/logging/StreamEndpoint.ts
+++ b/src/modules/logging/StreamEndpoint.ts
@@ -1,0 +1,128 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+import { Console } from 'console';
+import { Writable } from 'stream'
+import { ILogEndpoint, ILogEntry, ILogFormatter, IEndpointOptions, LogLevel, logging, Logger, DefaultFormatter } from './';
+
+export interface StreamEndpointOptions extends IEndpointOptions {
+    outStream?: Writable;
+    errStream?: Writable;
+}
+
+/** The StreamEndpoint will output to any `stream.Writable` type.
+    Separate streams can be used for <= INFO level and >= WARNING level messages (like stdout and stderr).
+    It is essentially a wrapper for Node's `Console` class which does the actual output. So for example a TRACE level
+    message will produce a stack dump just like `console.trace()` does.  Any arguments in the log entry are passed
+    on to `Console` methods, so formatting works the same way as the various `console.*` methods. If there are no arguments
+    then no extra formatting will take place (eg. to pre-format a message using some other method first).
+
+    This endpoint type is mainly useful for subclassing, though it could be used directly as well.
+    The Console and File endpoints are subclasses of this one.
+*/
+export default class StreamEndpoint implements ILogEndpoint
+{
+    readonly name: string = "Stream";
+
+    protected level: LogLevel = LogLevel.ANY;
+    protected formatter: ILogFormatter = new DefaultFormatter();
+    protected logger: Logger;
+    protected outStream: Writable | null = null;
+    protected errStream: Writable | null = null;
+
+    private cnsl: Console | null = null;
+
+    // c'tor overloads
+    constructor(streamOptions?: StreamEndpointOptions);
+    constructor(stream: Writable, options?: IEndpointOptions);
+    constructor(outStream: Writable, errStream: Writable, options?: IEndpointOptions);
+    // implementation
+    constructor(
+        streamOptionsOrOut?: StreamEndpointOptions | Writable,
+        optionsOrErr?: Writable | IEndpointOptions,
+        options?: IEndpointOptions
+    ) {
+        this.logger = logging().getLogger('logging');
+        const opts: StreamEndpointOptions = {
+            outStream: streamOptionsOrOut instanceof Writable ? streamOptionsOrOut : streamOptionsOrOut?.outStream,
+            errStream: optionsOrErr instanceof Writable ? optionsOrErr : undefined
+        }
+
+        if (optionsOrErr && !(optionsOrErr instanceof Writable))
+            Object.assign(opts, optionsOrErr);
+        else if (options)
+            Object.assign(opts, options);
+
+        this.options = opts;
+    }
+
+    get uid(): string { return `${this.name}(${this.outStream},${this.errStream})`; }
+
+    get options(): IEndpointOptions {
+        return { minLevel: this.level, formatter: this.formatter };
+    }
+    set options(options: IEndpointOptions | any) {
+        if (typeof options.minLevel == "number")
+            this.level = options.minLevel;
+        if (options.formatter)
+            this.formatter = options.formatter;
+        if (options.outStream) {
+            this.close();
+            this.outStream = options.outStream;
+            this.errStream = options.errStream || null;
+            this.cnsl = new Console(options.outStream, !!options.errStream ? options.errStream : options.outStream);
+        }
+        else if (options.outStream === null && this.cnsl) {
+            this.close();
+        }
+    }
+
+    get minLevel(): LogLevel { return this.level; }
+    set minLevel(level: LogLevel) { this.options.minLevel = this.level = level; }
+
+    async logEntry(entry: ILogEntry)
+    {
+        if (!this.cnsl || entry.level < this.level)
+            return;
+
+        const msg = this.formatter.format(entry);
+        let fn: Function;
+        switch (entry.level) {
+            case LogLevel.TRACE:
+                fn = this.cnsl.trace;
+                break;
+            case LogLevel.DEBUG:
+            case LogLevel.INFO:
+                fn = this.cnsl.log;
+                break;
+            case LogLevel.WARNING:
+            case LogLevel.ERROR:
+            case LogLevel.CRITICAL:
+                fn = this.cnsl.error;
+                break;
+            default:
+                return;
+        }
+        if (entry.args && entry.args.length)
+            fn.apply(null, [msg, ...entry.args]);
+        else
+            fn(msg);
+    }
+
+    close()
+    {
+        try {
+            if (this.outStream)
+                this.outStream.end();
+            if (this.errStream)
+                this.errStream.end();
+        }
+        catch { }
+        this.cnsl = null;
+        this.outStream = null;
+        this.errStream = null;
+    }
+
+}

--- a/src/modules/logging/endpoints.ts
+++ b/src/modules/logging/endpoints.ts
@@ -1,0 +1,9 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+
+export { default as ConsoleEndpoint } from './ConsoleEndpoint'
+export { default as FileEndpoint } from './FileEndpoint'
+export { default as StreamEndpoint } from './StreamEndpoint'

--- a/src/modules/logging/index.ts
+++ b/src/modules/logging/index.ts
@@ -1,0 +1,15 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+
+export * from './interface'
+export * from './LogLevel'
+export { default as logging /* , LogManager */ } from './LogManager'
+export { default as Logger } from './Logger'
+export { default as DefaultFormatter, MessagePreFormatter } from './DefaultFormatter'
+export { default as ConsoleFormatter } from './ConsoleFormatter'
+export { default as ConsoleEndpoint } from './ConsoleEndpoint'
+export { default as FileEndpoint } from './FileEndpoint'
+export { default as StreamEndpoint } from './StreamEndpoint'

--- a/src/modules/logging/interface.ts
+++ b/src/modules/logging/interface.ts
@@ -1,0 +1,45 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+import {LogLevel} from "./";
+
+/** This interface defines the overall logging configuration for minimum logging level(s) and endpoints to use.
+    An object of this type can be passed to `LogManager`'s `configure()` method or read from JSON data with the corresponding methods. */
+export interface ILogOptions {
+    /** Minimum logging levels per module eg.  { "": LogLevel.INFO, "tricky-module": LogLevel.DEBUG, ... } */
+    modules: { [module: string]: LogLevel },
+    /** Endpoint(s) to use and their options. eg. `{ "File": { minLevel: LogLevel.INFO, file: "/var/log/example.txt", ... } }`  */
+    endpoints?: { [name: string]: IEndpointOptions | any }
+}
+
+/** Defines common options for all endpoints. Some endpoints may extended these options with more specific ones. */
+export interface IEndpointOptions {
+    minLevel?: LogLevel;         // Minimum level for this endpoint, overrides any per-module or global level.
+    formatter?: ILogFormatter;   // Formatter class to use for formatting the final output.
+}
+
+/** Defines a logging output endpoint object. */
+export interface ILogEndpoint {
+    readonly name: string;    // a static name which should match the first part of the class name, like "Console"
+    readonly uid: string;     // a unique ID for a particular instance of an endpoint. eg. "FileEndpoint(/var/log/example.txt)"
+    options: IEndpointOptions | any;
+    logEntry: (logEntry: ILogEntry) => void;
+    close: () => void;
+}
+
+/** Defines a log message formatter object. */
+export interface ILogFormatter {
+    format: (logEntry: ILogEntry) => string;
+}
+
+/** Defines a log entry object. */
+export interface ILogEntry {
+    level: LogLevel;
+    timestamp: Date;
+    module: string;
+    location?: string;
+    message: any;
+    args?: any[]
+}

--- a/src/modules/logging/utils.ts
+++ b/src/modules/logging/utils.ts
@@ -4,23 +4,24 @@
     License: MIT
 */
 const n2s = (n: number) => n.toString().padStart(2, '0');
+const n2s3 = (n: number) => n.toString().padStart(3, '0');
 
 // MM-DD HH:MM:SS.zzz
 export function formatDateTimeUTC(ts: Date): string
 {
-    return `${n2s(ts.getUTCMonth()+1)}-${n2s(ts.getUTCDate())} ${n2s(ts.getUTCHours())}:${n2s(ts.getUTCMinutes())}:${n2s(ts.getUTCSeconds())}.${n2s(ts.getUTCMilliseconds())}`;
+    return `${n2s(ts.getUTCMonth()+1)}-${n2s(ts.getUTCDate())} ${n2s(ts.getUTCHours())}:${n2s(ts.getUTCMinutes())}:${n2s(ts.getUTCSeconds())}.${n2s3(ts.getUTCMilliseconds())}`;
 }
 
 // MM-DD HH:MM:SS.zzz
 export function formatDateTimeLocal(ts: Date): string
 {
-    return `${n2s(ts.getMonth()+1)}-${n2s(ts.getDate())} ${n2s(ts.getHours())}:${n2s(ts.getMinutes())}:${n2s(ts.getSeconds())}.${n2s(ts.getMilliseconds())}`;
+    return `${n2s(ts.getMonth()+1)}-${n2s(ts.getDate())} ${n2s(ts.getHours())}:${n2s(ts.getMinutes())}:${n2s(ts.getSeconds())}.${n2s3(ts.getMilliseconds())}`;
 }
 
 // HH:MM:SS.zzz
 export function formatTimeLocal(ts: Date): string
 {
-    return `${n2s(ts.getHours())}:${n2s(ts.getMinutes())}:${n2s(ts.getSeconds())}.${n2s(ts.getMilliseconds())}`;
+    return `${n2s(ts.getHours())}:${n2s(ts.getMinutes())}:${n2s(ts.getSeconds())}.${n2s3(ts.getMilliseconds())}`;
 }
 
 // MMDDTHHMMSS

--- a/src/modules/logging/utils.ts
+++ b/src/modules/logging/utils.ts
@@ -1,0 +1,30 @@
+/*
+    Simple logging framework.
+    Copyright Maxim Paperno, all rights reserved.
+    License: MIT
+*/
+const n2s = (n: number) => n.toString().padStart(2, '0');
+
+// MM-DD HH:MM:SS.zzz
+export function formatDateTimeUTC(ts: Date): string
+{
+    return `${n2s(ts.getUTCMonth()+1)}-${n2s(ts.getUTCDate())} ${n2s(ts.getUTCHours())}:${n2s(ts.getUTCMinutes())}:${n2s(ts.getUTCSeconds())}.${n2s(ts.getUTCMilliseconds())}`;
+}
+
+// MM-DD HH:MM:SS.zzz
+export function formatDateTimeLocal(ts: Date): string
+{
+    return `${n2s(ts.getMonth()+1)}-${n2s(ts.getDate())} ${n2s(ts.getHours())}:${n2s(ts.getMinutes())}:${n2s(ts.getSeconds())}.${n2s(ts.getMilliseconds())}`;
+}
+
+// HH:MM:SS.zzz
+export function formatTimeLocal(ts: Date): string
+{
+    return `${n2s(ts.getHours())}:${n2s(ts.getMinutes())}:${n2s(ts.getSeconds())}.${n2s(ts.getMilliseconds())}`;
+}
+
+// MMDDTHHMMSS
+export function formatDateTimeFileStamp(ts: Date): string
+{
+    return `${n2s(ts.getMonth()+1)}${n2s(ts.getDate())}T${n2s(ts.getHours())}${n2s(ts.getMinutes())}${n2s(ts.getSeconds())}`;
+}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,6 @@
-import { logIt } from '../common'
 import { Alignment } from '../modules/enums';
 import { PointType } from '../modules/geometry';
+import { logging } from '../modules/logging';
 
 // Used to validate if a string is a single numeric value. Accepts leading sign, base prefix (0x/0b/0o), decimals, and exponential notation.
 const NUMBER_VALIDATION_REGEX = new RegExp(/^[+-]?(?:0[xbo])?\d+(?:\.\d*)?(?:e[+-]?\d+)?$/);
@@ -23,7 +23,7 @@ export function evaluateValue(value: string): number {
         return (new Function( `"use strict"; return (${value})`))() || 0;
     }
     catch (e) {
-        logIt("WARN", "Error evaluating the numeric expression '" + value + "':", e)
+        logging().getLogger('plugin').warn("Error evaluating the numeric expression '" + value + "':", e)
         return 0
     }
 }
@@ -38,7 +38,7 @@ export function evaluateStringValue(value: string): string {
         return (new Function('return `' + value + '`')());
     }
     catch (e) {
-        logIt("WARN", "Error evaluating the string expression '" + value + "':", e)
+        logging().getLogger('plugin').warn("Error evaluating the string expression '" + value + "':", e)
         return value
     }
 }


### PR DESCRIPTION
This adds a basic but fairly flexible logging module that I whipped up, so to speak.

* It can log to console and/or file (and can be expanded for other destination/endpoints).
* Severity level of logged messages can be controlled per named module and per endpoint. Examples:
  * Only output warning-level messages from 'image cache' module but info-level from main plugin.
  * Set an endpoint minimum level to "none" to disable output entirely.
* Configuration (minimum levels and endpoints) can be read from a JSON file (as well as set programmatically of course).
* The file endpoint has configurable file path/name and settings for maximum log size and number of old log files to keep. Logs are rotated when the max. size is reached.
* Message formatting is done using interchangeable "formatter" classes which can be set per endpoint (eg. different formats for console and file outputs).
* Debug and trace-level messages capture the function/file/line number of where the log method was called from.
* The console logger color-codes the various log entry parts (timestamp, module, etc).
* The console and file outputs (which share a common base class) use Node's `Console` for the final formatting and writing, so the logging behavior is essentially unchanged in terms of formatting of the various `log()` calls (eg. variable number of arguments are supported and `%` style placeholders are replaced as usual). Console output is split between stdout and stderr also as usual (warning and errors to stderr).

I added a logging configuration file to be shipped with the plugin which disables console logging (or rather logging to TP's log), and configures a log file in the plugin's install folder named "dynamic-icons-log.txt" with a max. size of 20MB and keeping 7 old logs (that's probably too large now that I think about it more...). So for example a user could temporarily enable debug logging to help us troubleshoot something, or choose to enable "console" logging to TP's log, etc.  For now the config file is also in the install folder, so it will get overwritten during a plugin update, but perhaps we can change this in the future.

For local development I keep a "plugin-config.json" in the project root which enables console and debug, etc.

If there is no configuration file or it can't be loaded for some reason, the plugin falls back to logging to the console at "info" level.

And one final piece, when the plugin is started with NO console logging enabled (eg. just a file, like it would be when running from TP), it will redirect `stdout` to the log file, meaning it will capture all `TPClient` messages as well.  We can't do that if the plugin itself is logging to `stdout` of course, but in that case it doesn't really matter anyway.  There's some comments in index.ts where it does this, explaining how rather rudimentary this workaround is for now.

I've also added some hooks in the main plugin to try to exit more gracefully in various scenarios, and try not to kill the process unnecessarily if it can be avoided.  Mostly this just adds nice divisions in the log file to separate plugin runs, but it also helps "properly" close any file handles and such before exiting (I'm not really sure how much this matters in a Node app, but better clean than sorry I figure).

Here are some example logging outputs...

File:
```
08-22 16:56:52.119 [INF] {plugin} =============== Touch Portal Dynamic Icons started, connecting to Touch Portal... ===============
08-22 16:56:52.124 [INF] {plugin} Connected to Touch Portal v3.1.7.1.7 with running plugin v1.2.0-alpha2.14 (entry.tp v1020003)
08-22 16:57:18.600 [DBG] {imgcache} Image cache miss for gauges\svg\asi\asi_back.svg; Returned: Image { width: 294, height: 294 }  [@ modules\ImageCache.js:101:26]
08-22 16:58:19.154 [INF] {imgcache} Removed cached image gauges\svg\asi\asi_back.svg for icon 'DI_ASIGauge'.
```

Console (green text is my default color):
![image](https://github.com/spdermn02/TouchPortal-Dynamic-Icons/assets/1366615/5de940f2-dc6b-4430-9ef0-a8c9d3969073)


Trace types produce a stack dump, and critical type throws an exception (which then also prints a stack dump once handled).