### PR TITLE
Update sharp package to 0.32.5 (2nd try)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "async-mutex": "^0.4.0",
-        "sharp": "0.30.7",
+        "sharp": "^0.32.5",
         "skia-canvas": "mpaperno/skia-canvas#1.0.3",
-        "touchportal-api": "spdermn02/touchportal-node-api#mp/pkg_install"
+        "touchportal-api": "spdermn02/touchportal-node-api#master"
       },
       "bin": {
         "touchportal-dynamic-icons": "dist/index.js"
@@ -1111,6 +1111,11 @@
       "engines": {
         "node": ">= 4.5.0"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2653,6 +2658,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -4236,9 +4246,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.13",
@@ -4935,6 +4945,11 @@
         }
       ]
     },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5358,25 +5373,45 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.30.7",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.7.tgz",
-      "integrity": "sha512-G+MY2YW33jgflKPTXXptVO28HvNOo9G3j0MybYAHeEmby+QuD2U98dT6ueht9cv/XDqZspSpIhoSW+BAKJ7Hig==",
+      "version": "0.32.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.5.tgz",
+      "integrity": "sha512-0dap3iysgDkNaPOaOL4X/0akdu0ma62GcdC2NBQ+93eqpePdDdr2/LM0sFdDSMmN7yS+odyZtPsb7tx/cYBKnQ==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.2.3",
-        "detect-libc": "^2.0.1",
-        "node-addon-api": "^5.0.0",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
         "prebuild-install": "^7.1.1",
-        "semver": "^7.3.7",
+        "semver": "^7.5.4",
         "simple-get": "^4.0.1",
-        "tar-fs": "^2.1.1",
+        "tar-fs": "^3.0.4",
         "tunnel-agent": "^0.6.0"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14.15.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/tar-fs": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+      "dependencies": {
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      }
+    },
+    "node_modules/sharp/node_modules/tar-stream": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/shebang-command": {
@@ -5867,6 +5902,15 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
+    },
+    "node_modules/streamx": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
+      "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
+      "dependencies": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/spdermn02/TouchPortal-Dynamic-Icons#readme",
   "dependencies": {
     "async-mutex": "^0.4.0",
-    "sharp": "0.30.7",
+    "sharp": "^0.32.5",
     "skia-canvas": "mpaperno/skia-canvas#1.0.3",
     "touchportal-api": "spdermn02/touchportal-node-api#master"
   },

--- a/src/modules/DynamicIcon.ts
+++ b/src/modules/DynamicIcon.ts
@@ -138,8 +138,6 @@ export default class DynamicIcon
                 const size = this.actualSize(),
                     tileW = Math.ceil(size.width / this.tile.x),
                     tileH = Math.ceil(size.height / this.tile.y);
-                // the sharp() constructor may throw
-                const img = new sharp(data, { premultiplied: true });
                 for (let y=0; y < this.tile.y; ++y) {
                     for (let x=0; x < this.tile.x; ++x) {
                         const tl = tileW * x,
@@ -147,7 +145,8 @@ export default class DynamicIcon
                             tw = Math.min(tileW, size.width - tl),
                             th = Math.min(tileH, size.height - tt);
                         // extract image slice, encode PNG, and send the tile
-                        img.extract({ left: tl, top: tt, width: tw, height: th })
+                        // the sharp() constructor may throw
+                        new sharp(data).extract({ left: tl, top: tt, width: tw, height: th })
                         .png(this.outputCompressionOptions)
                         .toBuffer()
                         .then((data: Buffer) => this.sendStateData(this.getTileStateId({x: x, y: y}), data) )


### PR DESCRIPTION
After discussion with Sharp author, this seems like a good fix for the original issue with tile extraction w/out apparent performance impact. Allows updating to latest libvips, which significantly improves compression performance (whereas tiling is now a secondary feature anyway).