### PR TITLE
Simple Round Gauge update

### DIFF
--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -221,7 +221,7 @@ function makeSizeTypeData(id, dflt = undefined) {
 // They accept an array (reference) as argument to store the data parameters into, and return the related format string.
 
 function makeIconLayerCommonData(id, withIndex = false) {
-    let format = "Icon\nName{0}";
+    let format = "Icon\nName {0}";
     const data = [ makeIconNameData(id) ];
     if (withIndex) {
         format += "Element\n@ Position{1}";
@@ -382,8 +382,8 @@ function makeBorderRadiusData(id, /* out */ data, r = 0) {
 function layerInfoText(what = "", layerOnly = true) {
     return (what ? `To add this ${what} as a layer, an ` : "") + "Icon with same Name must first have been created" + (layerOnly ? " with a 'New' action" : "") + ". "
 }
-function numericValueInfoText() {
-    return "Values can include math operators and JavaScript functions.";
+function numericValueInfoText(what = "Values") {
+    return what + " can include math operators and JavaScript functions.";
 }
 function txInfoText(wrapLine = 0) {
     return "" +
@@ -446,22 +446,27 @@ function addImageAction(id, name, withTx = true) {
 
 function addProgressGaugeAction(id, name) {
     const descript = "Dynamic Icons: " +
-        "Generate or layer a round progress-bar style gauge reflecting a data value.\n" + layerInfoText('gauge') + " " + numericValueInfoText();
+        "Generate or layer a round progress-bar style gauge reflecting a data value. " + layerInfoText('gauge') + "\n" +
+        "Gauge values are in percent where 100% is one complete circle. 'Automatic' direction draws clockwise for positive number, CCW for negative. " +
+        numericValueInfoText("All numeric fields") + " Note that zero starting degrees points East.";
     let [format, data] = makeIconLayerCommonData(id);
     let i = data.length;
     format +=
-        `with shadow {${i++}} of color {${i++}} using indicator color {${i++}} with highlight {${i++}} starting at degree {${i++}} ` +
-        `at value {${i++}} with cap style {${i++}} on background color {${i++}} in direction {${i++}}`;
+        `draw using\nindicator color {${i++}} with\nhighlight {${i++}} starting\nat degree {${i++}} ` +
+        `to value\n${SP_EM}${SP_EM}(%) {${i++}} with\nline width {${i++}}{${i++}} cap\nstyle {${i++}} diameter\n${SP_EM}${SP_EM}${SP_EN}(%) {${i++}} direction {${i++}}` +
+        `background\n${SP_EM}${SP_EM}${SP_EM}color {${i++}} shadow\n${SP_EM}color {${i++}}`;
     data.push(
-        makeChoiceData("gauge_shadow", "Gauge Shadow", ["On", "Off"]),
-        makeActionData("gauge_shadow_color", "color", "Gauge Shadow Color", "#282828FF"),
         makeActionData("gauge_color", "color", "Gauge Color", "#FFA500FF"),
         makeChoiceData("gauge_highlight", "Gauge Highlight", ["On", "Off"]),
-        makeNumericData("gauge_start_degree", "Gauge Start Degree", 180, 0, 360),
+        makeTextData("gauge_start_degree", "Gauge Start Degree", "180"),
         makeActionData("gauge_value", "text", "Gauge Value", "0"),
-        makeChoiceData("gauge_cap", "Gauge Icon Cap Type", ["round", "butt", "square"]),
+        makeTextData("gauge_line_width", "Line Width", "12"),
+        makeSizeTypeData("gauge_line_width"),
+        makeChoiceData("gauge_line_cap", "Gauge Icon Cap Type", ["round", "butt", "square"]),
+        makeTextData("gauge_radius", "Diameter", "78"),
+        makeChoiceData("gauge_counterclockwise", "Gauge Direction", ["Clockwise", "Counter CW", "Automatic"]),
         makeActionData("gauge_background_color", "color", "Gauge Background Color", "#000000FF"),
-        makeChoiceData("gauge_counterclockwise", "Gauge Direction", ["Clockwise", "Counter Clockwise"]),
+        makeActionData("gauge_shadow_color", "color", "Gauge Shadow Color", "#282828FF"),
     );
     addAction(id, name, descript, format, data, true);
 }

--- a/src/modules/elements/RoundProgressGauge.ts
+++ b/src/modules/elements/RoundProgressGauge.ts
@@ -3,66 +3,93 @@ import { ILayerElement, IValuedElement, RenderContext2D } from '../interfaces';
 import { M } from '../../utils/consts';
 import { ParseState } from '../';
 import { Rectangle } from '../geometry';
-import { BrushStyle } from './';
-import { evaluateValue } from '../../utils/helpers';
+import { LineStyle, BrushStyle } from './';
+import { evaluateValue, clamp } from '../../utils/helpers';
+
+const enum DrawDirection { CW, CCW, Auto }
 
 // Draws an arc/circle extending from 0 to 360 degrees based on a given value onto a canvas context.
 export default class RoundProgressGauge implements ILayerElement, IValuedElement
 {
-    value: number = 0
-    capStyle: CanvasLineCap = 'round'
-    indicatorColor: BrushStyle = new BrushStyle('#FFA500FF')
+    value: number = 0    // decimal percent, -1 through 1
     highlightOn = true
     shadowColor = new BrushStyle('#282828FF')
-    shadowOn = true
-    startingDegree = 180
-    counterClockwise = false
+    startAngle = 180 * M.D2R  // radians
+    direction: DrawDirection = DrawDirection.CW
     backgroundColor = new BrushStyle('#000000FF')
+    radius = 0.39  // approximates the original ratio of 100 for 256px icon size
+    lineStyle: LineStyle = new LineStyle({
+        width: 11.7,   // this line width preserves legacy default size before it was settable
+        cap: "round"
+    })
 
     // ILayerElement
-    get type() { return "RoundProgressGauge"; }
+    readonly type = "RoundProgressGauge"
     // IValuedElement
-    setValue(value: string) { this.value = evaluateValue(value); }
+    setValue(value: string) { this.value = evaluateValue(value) * .01; }
 
     loadFromActionData(state: ParseState): RoundProgressGauge {
         // the incoming data IDs should be structured with a naming convention
-        for (let i = state.pos, e = state.data.length; i < e; ++i) {
-            const data = state.data[i];
+        let lineParsed = false,
+            atEnd = false,
+            shadowOff = false
+        for (let e = state.data.length; state.pos < e && !atEnd;) {
+            const data = state.data[state.pos]
             const dataType = data.id.split('gauge_').at(-1);  // last part of the data ID determines its meaning
             switch (dataType) {
-                case 'shadow':
-                    this.shadowOn = (data.value === "On")
-                    break
-                case 'shadow_color':
-                    this.shadowColor.color = data.value
-                    break
                 case 'color':
-                    this.indicatorColor.color = data.value
+                    this.lineStyle.pen.color = data.value
                     break
                 case 'highlight':
                     this.highlightOn = (data.value === "On")
                     break
                 case 'start_degree':
-                    this.startingDegree = parseFloat(data.value) || this.startingDegree
+                    this.startAngle = evaluateValue(data.value) * M.D2R
                     break
                 case 'value':
                     this.setValue(data.value)
                     break
-                case 'cap':
-                    this.capStyle = data.value as CanvasLineCap
+                case 'radius':
+                    this.radius = clamp(evaluateValue(data.value), 2, 200) * .005
                     break
+                case 'counterclockwise': {
+                    const value = data.value.toLocaleLowerCase();
+                    this.direction = value.startsWith("clock") ? DrawDirection.CW :
+                        value.startsWith("auto") ? DrawDirection.Auto :
+                        DrawDirection.CCW
+                    break
+                }
                 case 'background_color':
                     this.backgroundColor.color = data.value
                     break
-                case 'counterclockwise':
-                    this.counterClockwise = data.value.toLowerCase() === 'counter clockwise'
+                case 'shadow_color':
+                    this.shadowColor.color = data.value
                     break
+
+                // legacy options, keep for BC with <v1.2
+                case 'shadow':
+                    shadowOff = (data.value == "Off")
+                    break
+                case 'cap':
+                    if (!lineParsed)
+                        this.lineStyle.cap = data.value as CanvasLineCap
+                    break
+
                 default:
-                    i = e  // end the loop on unknown field
-                    continue
+                    if (!lineParsed && dataType?.startsWith('line_')) {
+                        this.lineStyle.loadFromActionData(state)
+                        lineParsed = true
+                    }
+                    else {
+                        atEnd = true
+                    }
+                    continue  // do not increment position counter
             }
             ++state.pos;
         }
+        // force transparent shadow color if using old action with a shadow toggle option
+        if (shadowOff)
+            this.shadowColor.color = "#00000000"
         // console.dir(this);
         return this;
     }
@@ -70,37 +97,47 @@ export default class RoundProgressGauge implements ILayerElement, IValuedElement
     // ILayerElement
     render(ctx: RenderContext2D, rect: Rectangle): void {
 
+        let ccw = this.direction == DrawDirection.CCW  // check to invert the value for endAngle
         const cx = rect.width * .5,
             cy = rect.height * .5,
             minSize = Math.min(rect.width, rect.height),
-            radius = minSize * .39,  // approximates the original ratio of 100 for 256px icon size
-            startAngle = this.startingDegree * M.D2R,
-            endAngle = startAngle + M.PI2 * (this.counterClockwise ? -this.value : this.value) * .01,
+            radius = minSize * this.radius,
+            endAngle = this.startAngle + M.PI2 * (ccw ?  -this.value : this.value),
             currentFilter = ctx.filter,
             addFilter = currentFilter && currentFilter != "none" ? currentFilter + " " : ""
 
+        // set CCW arc draw direction if in Auto mode with negative value
+        if (!ccw && this.direction == DrawDirection.Auto && this.value < 0)
+            ccw = true
+
+        // relative stroke width is percentage of half the overall size where 100% would be half the smaller of width/height (and strokes would overlay the whole shape)
+        if (this.lineStyle.width.isRelative)
+            this.lineStyle.widthScale = minSize * .005
+        // radius of the indicator, adjusted for stroke width
+        const indRadius = (radius - this.lineStyle.scaledWidth * .25)
+
         ctx.save()
 
-        ctx.lineCap = this.capStyle
+        ctx.lineCap = this.lineStyle.cap
 
-        if (this.shadowOn && !this.shadowColor.isEmpty) {
+        if (!this.shadowColor.isEmpty) {
             //Shadow
             ctx.beginPath()
             ctx.arc(cx, cy, radius+5, 0, M.PI2)
             ctx.fillStyle = this.shadowColor.style
             ctx.filter = addFilter + 'blur(5px)'
             ctx.fill()
-            ctx.filter = currentFilter;
+            ctx.filter = currentFilter
         }
 
-        if (this.highlightOn && !this.indicatorColor.isEmpty) {
+        if (this.highlightOn && !this.lineStyle.isEmpty) {
             ctx.beginPath();
-            ctx.arc(cx, cy, radius, startAngle, endAngle, this.counterClockwise)
-            ctx.strokeStyle = this.indicatorColor.style
-            ctx.lineWidth = Math.max(minSize * .012, 1)
+            ctx.arc(cx, cy, indRadius, this.startAngle, endAngle, ccw)
+            ctx.strokeStyle = this.lineStyle.pen.color
+            ctx.lineWidth = Math.max(this.lineStyle.scaledWidth * .2, 1)
             ctx.filter = addFilter + 'blur(5px)'
             ctx.stroke()
-            ctx.filter = currentFilter;
+            ctx.filter = currentFilter
         }
 
         if (!this.backgroundColor.isEmpty) {
@@ -110,11 +147,11 @@ export default class RoundProgressGauge implements ILayerElement, IValuedElement
             ctx.fill()
         }
 
-        if (!this.indicatorColor.isEmpty) {
+        if (!this.lineStyle.isEmpty) {
             ctx.beginPath();
-            ctx.arc(cx,cy,radius * .9, startAngle, endAngle, this.counterClockwise)
-            ctx.strokeStyle = this.indicatorColor.style
-            ctx.lineWidth = minSize * .0585
+            ctx.arc(cx,cy, indRadius * .925, this.startAngle, endAngle, ccw)
+            ctx.strokeStyle = this.lineStyle.pen.color
+            ctx.lineWidth = this.lineStyle.scaledWidth
             ctx.stroke();
         }
 


### PR DESCRIPTION
- Add line width and diameter properties;
- Add "auto" direction to toggle CCW with negative values;
- Remove shadow toggle property (BC preserved, use transparent to disable shadow);
- Fix that could not set a starting degree of zero;
- Move shadow color to end of action's properties list;
- Make start degrees action data field be text type for dynamic evaluation (also allows negatives);

Being able to adjust the diameter and width of the stroke opens up some more uses for the gauge. For example one could use it to draw a color "sweep" anywhere on an image. Like on this gauge the white (on right side), green, and yellow sweeps behind the tick marks are drawn with the SRG (because these ranges vary by airplane model so the gauge can adapt, vs. using static images):

![image](https://github.com/spdermn02/TouchPortal-Dynamic-Icons/assets/1366615/73b57841-2869-4442-ae47-c281114f33df)

The action now looks like this:
![image](https://github.com/spdermn02/TouchPortal-Dynamic-Icons/assets/1366615/ba430a41-f209-49bc-a1c4-94b5827089d4)

I kinda randomly came up with using a diameter vs. radius for the action, but I think it's simpler to figure out...?  Diameter is percent of overall icon size, vs. with radius one has to do math...  :)   But it could go either way.

"Auto" direction means it will sweep clockwise for positive values and CCW for negative values. There was no way to make it do that before, so that's an interesting feature, I think, w/out using any new data fields  :)

I removed the shadow toggle field to save space, since it seemed a bit redundant or inconsistent... eg. to remove the background one makes it transparent (as will all the other styling in the plugin).  But it could certainly be replaced.

-Max

PS. One advantage of specifying a diameter vs. using a transformation to change the size is that the stroke width isn't being scaled as well.  Here's another example with stacked SRGs of different diameters, with the same stroke width for each.  Before, I did this with transforms, but the strokes never matched since they scaled.
![image](https://github.com/spdermn02/TouchPortal-Dynamic-Icons/assets/1366615/070780c8-1c1c-41c2-8640-c19658dae7a0)

Of course now both diameter and stroke can be set, but it's still much simpler w/out using transforms.