### PR TITLE
Add "Update a Color" action to dynamically change icon layer color properties.

### DIFF
--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -767,6 +767,23 @@ function addValueUpdateAction(id, name) {
     addAction(id, name, descript, format, data);
 }
 
+function addColorUpdateAction(id, name) {
+    const descript = "Dynamic Icons: " +
+        "Update a color on an element in an existing icon. " +
+        "Elements which can be updated: Round Gauge and Bar Graph forground/background, Progress Bar value/container fill, and fill/stroke on Text, Styled Rectangle, and Path Style actions.\n" +
+        "Icon with same Name must already exist and contain a supported element type at the specified position. " +
+        "Position indexes start at 1 (non-layered icons have only one position). Specify a negative index to count from the bottom of a layer stack.";
+    let [format, data] = makeIconLayerCommonData(id, true);
+    let i = data.length;
+    format += ` set {${i++}} color to {${i++}} and render icon? {${i++}}`;
+    data.push(
+        makeChoiceData(jid(id, "type"), "Type", C.COLOR_UPDATE_TYPE_CHOICES),
+        makeColorData(jid(id, "color"), "Color", "#00000000"),
+        makeChoiceData(jid(id, "render"), "Render?", ["No", "Yes"]),
+    );
+    addAction(id, name, descript, format, data);
+}
+
 // System utility action
 
 function addSystemActions() {
@@ -805,6 +822,7 @@ addClipAction(           jid(iid, C.Act.IconClip),      "Paths - Clipping Mask f
 
 addTransformAction(      jid(iid, C.Act.IconSetTx),     "Animate - Transformation", true);
 addValueUpdateAction(    jid(iid, C.Act.IconSetValue),  "Animate - Update a Value");
+addColorUpdateAction(    jid(iid, C.Act.IconSetColor),  "Animate - Update a Color");
 
 // Misc actions
 addSystemActions();

--- a/src/modules/elements/DrawingStyle.ts
+++ b/src/modules/elements/DrawingStyle.ts
@@ -1,11 +1,11 @@
 import { assignExistingProperties, parseNumericArrayString, } from '../../utils';
-import { IPathHandler, ILayerElement } from '../interfaces';
-import { LayerRole, ParseState, Path2D, Rectangle, RenderContext2D } from '../';
+import { IColorElement, ILayerElement, IPathHandler } from '../interfaces';
+import { ColorUpdateType, LayerRole, ParseState, Path2D, Rectangle, RenderContext2D } from '../';
 import { BrushStyle, StrokeStyle, ShadowStyle } from './';
 import { Act, Str } from '../../utils/consts';
 
 // Applies a drawing style to a canvas context, which includes all fill, stroke, and shadow attributes.
-export default class DrawingStyle implements ILayerElement, IPathHandler
+export default class DrawingStyle implements ILayerElement, IPathHandler, IColorElement
 {
     fill: BrushStyle;
     fillRule: CanvasFillRule = 'nonzero';
@@ -26,6 +26,23 @@ export default class DrawingStyle implements ILayerElement, IPathHandler
 
     /** Returns true if there is nothing at all to draw for this style: fill is transparent, stroke is zero size, and there is no shadow.  */
     get isEmpty(): boolean { return this.fill.isEmpty && this.line.isEmpty && this.shadow.isEmpty; }
+
+    // IColorElement
+    setColor(value: string, type: ColorUpdateType): void {
+        // Even though ColorUpdateType is a bitfield flag, currently nothing is going to
+        // update multiple properties at once, so we can shortcut here.
+        switch (type) {
+            case ColorUpdateType.Fill:
+                this.fill.color = value;
+                break;
+            case ColorUpdateType.Stroke:
+                this.line.pen.color = value;
+                break;
+            case ColorUpdateType.Shadow:
+                this.shadow.color = value;
+                break;
+        }
+    }
 
     loadFromActionData(state: ParseState, dataIdPrefix:string = ""): DrawingStyle {
         dataIdPrefix += Act.IconStyle + Str.IdSep;

--- a/src/modules/elements/LinearProgressBar.ts
+++ b/src/modules/elements/LinearProgressBar.ts
@@ -1,6 +1,6 @@
 
-import { ILayerElement, IValuedElement } from '../interfaces';
-import { Orientation, ParseState, Path2D, Rectangle, RenderContext2D, SizeType, Size, UnitValue } from '../';
+import { IColorElement, ILayerElement, IValuedElement } from '../interfaces';
+import { Orientation, ParseState, Path2D, Rectangle, RenderContext2D, SizeType, Size, UnitValue, ColorUpdateType } from '../';
 import { arraysMatchExactly, evaluateValue, round3p } from '../../utils'
 import { DrawingStyle } from './';
 import StyledRectangle from './StyledRectangle';
@@ -8,7 +8,7 @@ import StyledRectangle from './StyledRectangle';
 const enum DrawDirection { Normal, Reverse, Center };
 
 // Draws a rectangle shape on a canvas context with optional radii applied to any/all of the 4 corners (like CSS). The shape can be fully styled with the embedded DrawingStyle property.
-export default class LinearProgressBar extends StyledRectangle implements ILayerElement, IValuedElement
+export default class LinearProgressBar extends StyledRectangle implements ILayerElement, IValuedElement, IColorElement
 {
     orientation: Orientation = Orientation.H;
     direction: DrawDirection = DrawDirection.Normal;
@@ -27,6 +27,14 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
 
     // IValuedElement
     setValue(value: string) { this.value = Math.min(Math.max(evaluateValue(value), 0), 100); }
+
+    // IColorElement
+    setColor(value: string, type: ColorUpdateType): void {
+        if (type & ColorUpdateType.Foreground)
+            this.valueStyle.setColor(value, ColorUpdateType.Fill);
+        else
+            this.style.setColor(value, type);
+    }
 
     /** Returns true if there is nothing to draw: size is empty, colors are blank or transparent, or there is no fill and stroke width is zero */
     get isEmpty(): boolean {

--- a/src/modules/elements/RoundProgressGauge.ts
+++ b/src/modules/elements/RoundProgressGauge.ts
@@ -1,6 +1,6 @@
 
-import { ILayerElement, IRenderable, IValuedElement } from '../interfaces';
-import { ParseState, Rectangle, RenderContext2D } from '../';
+import { IColorElement, ILayerElement, IRenderable, IValuedElement } from '../interfaces';
+import { ColorUpdateType, ParseState, Rectangle, RenderContext2D } from '../';
 import { StrokeStyle, BrushStyle } from './';
 import { evaluateValue, clamp } from '../../utils';
 import { M } from '../../utils/consts';
@@ -8,7 +8,7 @@ import { M } from '../../utils/consts';
 const enum DrawDirection { CW, CCW, Auto }
 
 // Draws an arc/circle extending from 0 to 360 degrees based on a given value onto a canvas context.
-export default class RoundProgressGauge implements ILayerElement, IRenderable, IValuedElement
+export default class RoundProgressGauge implements ILayerElement, IRenderable, IValuedElement, IColorElement
 {
     value: number = 0    // decimal percent, -1 through 1
     highlightOn = true
@@ -26,6 +26,21 @@ export default class RoundProgressGauge implements ILayerElement, IRenderable, I
     readonly type = "RoundProgressGauge"
     // IValuedElement
     setValue(value: string) { this.value = evaluateValue(value) * .01; }
+
+    // IColorElement
+    setColor(value: string, type: ColorUpdateType): void {
+        switch (type) {
+            case ColorUpdateType.Foreground:
+                this.lineStyle.pen.color = value;
+                break;
+            case ColorUpdateType.Background:
+                this.backgroundColor.color = value;
+                break;
+            case ColorUpdateType.Shadow:
+                this.shadowColor.color = value;
+                break;
+        }
+    }
 
     loadFromActionData(state: ParseState): RoundProgressGauge {
         // the incoming data IDs should be structured with a naming convention

--- a/src/modules/elements/StyledRectangle.ts
+++ b/src/modules/elements/StyledRectangle.ts
@@ -1,13 +1,13 @@
 
-import { ILayerElement, IRenderable } from '../interfaces';
-import { LayerRole, ParseState, Rectangle, RenderContext2D } from '../';
+import { IColorElement, ILayerElement, IRenderable } from '../interfaces';
+import { ColorUpdateType, LayerRole, ParseState, Rectangle, RenderContext2D } from '../';
 import { DrawingStyle } from './';
 import { arraysMatchExactly, round3p } from '../../utils';
 import { Act, Str } from '../../utils/consts';
 import RectanglePath from './RectanglePath';  // must be direct import for subclass
 
 // Draws a rectangle shape on a canvas context with optional radii applied to any/all of the 4 corners (like CSS). The shape can be fully styled with the embedded DrawingStyle property.
-export default class StyledRectangle extends RectanglePath implements ILayerElement, IRenderable
+export default class StyledRectangle extends RectanglePath implements ILayerElement, IRenderable, IColorElement
 {
     style: DrawingStyle = new DrawingStyle();
     /** Whether to adjust (reduce) the overall drawing area size to account for shadow offset/blur. */
@@ -23,6 +23,9 @@ export default class StyledRectangle extends RectanglePath implements ILayerElem
     get isEmpty(): boolean {
         return this.style.fill.isEmpty && this.style.line.isEmpty;
     }
+
+    // IColorElement
+    setColor(value: string, type: ColorUpdateType): void { this.style.setColor(value, type); }
 
     loadFromActionData(state: ParseState): StyledRectangle {
         super.loadFromActionData(state, Act.IconRect);

--- a/src/modules/elements/StyledText.ts
+++ b/src/modules/elements/StyledText.ts
@@ -1,11 +1,11 @@
 
-import { ILayerElement, IRenderable, IValuedElement } from '../interfaces';
-import { Alignment, ParseState, Point, PointType, Rectangle, RenderContext2D } from '../';
+import { IColorElement, ILayerElement, IRenderable, IValuedElement } from '../interfaces';
+import { Alignment, ColorUpdateType, ParseState, Point, PointType, Rectangle, RenderContext2D } from '../';
 import { evaluateValue, evaluateStringValue, parseAlignmentFromValue } from '../../utils'
 import { DrawingStyle } from './';
 
 // Draws text on a canvas context with various options. The text can be fully styled with the embedded DrawingStyle property.
-export default class StyledText implements ILayerElement, IRenderable, IValuedElement
+export default class StyledText implements ILayerElement, IRenderable, IValuedElement, IColorElement
 {
     // These are all private because changing them will affect the cached text metrics.
     // Value string can be accessed with value/setValue(). Other accessors can be added as needed.
@@ -39,6 +39,9 @@ export default class StyledText implements ILayerElement, IRenderable, IValuedEl
         this.text = evaluateStringValue(text);
         this.metrics.textMetrics = null;  // reset
     }
+
+    // IColorElement
+    setColor(value: string, type: ColorUpdateType): void { this.style.setColor(value, type); }
 
     loadFromActionData(state: ParseState): StyledText {
         let styleParsed = false;

--- a/src/modules/enums.ts
+++ b/src/modules/enums.ts
@@ -40,3 +40,16 @@ export const enum TransformOpType {
     Scale = 'SC',
     Skew = 'SK',
 }
+
+// Flags type for possible future use. No element currently supports setting multple properties at once.
+export const enum ColorUpdateType {
+    None      = 0,
+    Stroke    = 0x01,
+    Fill      = 0x02,
+    Shadow    = 0x04,
+    Primary   = 0x10,
+    Secondary = 0x20,
+    // aliases
+    Foreground = Stroke,
+    Background = Fill,
+}

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -1,5 +1,5 @@
 
-import { LayerRole } from './enums';
+import { ColorUpdateType, LayerRole } from './enums';
 import { Rectangle } from './geometry';
 import { Path2D, RenderContext2D } from './types';
 
@@ -14,16 +14,21 @@ export interface IRenderable extends ILayerElement {
     render(context: RenderContext2D, rect?:Rectangle): Promise<void> | void;
 }
 
-// An interface with a "setValue()" method. Elements which can reflect value(s) can implement this to update data w/out re-creating the element.
-// Really this is just to make TypeScript compiler happy... to check if an element "implements the interface" we have to check for existence/type of "setValue" property anyway.
-export interface IValuedElement extends ILayerElement {
-    setValue(value: string): void;
-}
-
 export interface IPathProducer extends ILayerElement {
     getPath(rect?: Rectangle, pathStack?: Array<Path2D>) : Path2D;
 }
 
 export interface IPathHandler extends ILayerElement {
     renderPaths(paths: Array<Path2D>, context?: RenderContext2D, rect?: Rectangle) : void;
+}
+
+// An interface with a "setValue()" method. Elements which can reflect value(s) can implement this to update data w/out re-creating the element.
+// Really this is just to make TypeScript compiler happy... to check if an element "implements the interface" we have to check for existence/type of "setValue" property anyway.
+export interface IValuedElement extends ILayerElement {
+    setValue(value: string): void;
+}
+
+// An interface with a "setColor()" method. Elements which use colors can implement this to update color values w/out re-creating the element.
+export interface IColorElement extends ILayerElement {
+    setColor(value: string, type: ColorUpdateType): void;
 }

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -48,6 +48,7 @@ export const enum Act {
     IconClip = "clip",
     IconSetTx = "set_tx",
     IconSetValue = "set_value",
+    IconSetColor = "set_color",
 }
 
 // Individual data IDs for various actions. These are the last, most relevant, part(s) if each ID.
@@ -68,6 +69,9 @@ export const enum DataValue {
     ClipMaskNormal  = "Create Normal",
     ClipMaskInverse = "Create Inverse",
     ClipMaskRelease = "Release",
+    ColorTypeStroke = "Stroke/Foreground",
+    ColorTypeFill   = "Fill/Background",
+    ColorTypeShadow = "Shadow",
     TxScopePreviousOne = "previous layer",
     TxScopeCumulative  = "all previous",
     TxScopeUntilReset  = "all following",
@@ -99,3 +103,5 @@ export const PATH_BOOL_OPERATION_CHOICES = [
     PathBoolOperation.None, PathBoolOperation.Add, PathBoolOperation.Complement,
     PathBoolOperation.Difference, PathBoolOperation.Intersect, PathBoolOperation.Union, PathBoolOperation.Xor
 ];
+export const COLOR_UPDATE_TYPE_CHOICES = [DataValue.ColorTypeStroke, DataValue.ColorTypeFill, DataValue.ColorTypeShadow];
+


### PR DESCRIPTION
Adds a new action to update a color of a relevant layer element.  A generic option selects which color to update for elements that have multiple colors.

![image](https://github.com/spdermn02/TouchPortal-Dynamic-Icons/assets/1366615/56d75bb4-f5b6-4f11-97e8-b35424f094ea)

Example usage:

![image](https://github.com/spdermn02/TouchPortal-Dynamic-Icons/assets/1366615/2d76c3a9-2826-4e45-b876-f65c0b1ee407)
