### PR TITLE
Add ability to load images from base64-encoded strings.

### DIFF
--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -498,7 +498,7 @@ function addTextAction(id, name) {
 function addImageAction(id, name, withTx = true) {
     let descript = "Dynamic Icons: " +
         `Generate or layer an image. ${layerInfoText('image')} ` +
-        "File paths are relative to this plugin's \"Default Image Files Path\" setting, or use absolute paths.\n";
+        "File paths are relative to this plugin's \"Default Image Files Path\" setting, or use absolute paths. Base64-encoded images can be loaded by using a \"data:\" prefix before the string data.\n";
     let [format, data] = makeIconLayerCommonData(id);
     let i = data.length;
     format += `Image\nFile {${i++}}Resize\nFit {${i++}}`;

--- a/src/modules/elements/DynamicImage.ts
+++ b/src/modules/elements/DynamicImage.ts
@@ -33,7 +33,7 @@ export default class DynamicImage implements ILayerElement, IRenderable, IValued
     setValue(value: string) {
         // Fixup \ in Windows paths to \\, otherwise they're treated as escapes in the following eval.
         // Ignore any value that contains a / to preserve code (eg. regex), since that's not a legal Windows path character anyway.
-        if (process.platform == "win32" && value.indexOf('/') < 0)
+        if (process.platform == "win32" && !value.startsWith("data:") && value.indexOf('/') < 0)
             value = value.replace(/\\/g, "\\\\");
         this.source = evaluateStringValue(value.trim());
     }


### PR DESCRIPTION
The "Image" action now accepts b64 image data strings by prefixing the source with "data:".

For example, using an existing dynamic icon image as a layer in a new icon:
![image](https://github.com/spdermn02/TouchPortal-Dynamic-Icons/assets/1366615/1c580850-4cf6-4fc2-af2b-ea60321f03c5)
