### PR TITLE
v1.3

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -13,15 +13,16 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version:  ${{ steps.pckg_ver.outputs.version }}
+      name:  ${{ steps.pckg_ver.outputs.name }}
     steps:
       - name: Checkout package.json
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/actions
 
       - name: "Get package version and check if release exists"
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: pckg_ver
         with:
           result-encoding: string
@@ -30,6 +31,7 @@ jobs:
               const pckgJson = require('./package.json');
               const v = pckgJson.version;
               core.setOutput('version', v);
+              core.setOutput('name', pckgJson.name);
               console.log("Package version is", v);
 
               const { owner, repo } = context.repo;
@@ -78,16 +80,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest, macos-latest, ubuntu-latest ]
+        os: [ windows-latest, macos-latest, macos-13, ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: NPM install
         run: |
@@ -95,15 +97,22 @@ jobs:
           mkdir ./Installers
 
       - name: Build
-        run: npm run build -- -p ${{ runner.os }}
+        run: npm run build
+
+      - id: get_os_arch
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: return `${process.env.RUNNER_OS}-${process.arch}`
 
       - name: Upload assets
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          archive_name: ${{ needs.release.outputs.name }}-${{ steps.get_os_arch.outputs.result }}-${{ needs.release.outputs.version }}.tpp
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: ./Installers/touchportal-dynamic-icons-${{ runner.os }}-${{ needs.release.outputs.version }}.tpp
-          asset_name: touchportal-dynamic-icons-${{ runner.os }}-${{ needs.release.outputs.version }}.tpp
+          asset_path: ./Installers/${{ env.archive_name }}
+          asset_name: ${{ env.archive_name }}
           asset_content_type: application/zip

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -1,0 +1,28 @@
+name: Test Builds
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, macos-latest, macos-13, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: NPM install
+        run: |
+          npm install
+          mkdir ./Installers
+
+      - name: Build
+        run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,54 @@
 
 # Touch Portal Dynamic Icons - Change Log
 
+## v1.3.0
+
+### New Features
+- Added "Circular Tick Marks" and "Linear Tick Marks" actions for drawing gauge "ticks" and/or labels with multiple options (TP v4+ only).
+- Added "Run Custom Script" action to run user-provided JavaScript code with access to current Canvas context for custom drawing (see [Custom Scripts] wiki page for details).
+- Added "Save Icon to File" action to export generated images to files in various formats. This can be found in the "Layer Actions" group.
+  - Available export formats: AVIF, GIF, JPEG, PNG, TIFF, & WebP.
+  - Each export format has various options (such as compression level, quality, etc) that can be specified in a "option=value, ..." list and have been documented in the wiki: [File Output Options].
+- Added `vw`, `vh`, `vmin` & `vmax` relative size unit types for use in font sizing and other CSS-like properties. These correspond to the [standard CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh) versions and represent 1 percent of the current icon size ("viewport") width & height, or minium/maximum of the width or height, respectively. E.g. `5vh` is 5% of the icon height, or `5vmin` is 5% of the smaller of icon width or height.
+- Added new "Wrap Width" option to "Draw - Text" action which will automatically wrap long text to the specified width if it won't fit on one line.
+- Added option to control color quality (number of colors) of generated images to help further reduce image data size. Default value is available as a new plugin setting and the quality can also be set per layered icon in the "Generate" action.
+- Added new plugin setting to control the maximum number of threads used by `skia-canvas` for drawing images.
+
+### Changes
+- SVG images are now kept as scalable vector graphics instead of being rasterized at a fixed size during initial loading. This prevents any pixelation due to scaling, including when manipulating the image with transformations. However, it comes with some caveats:
+  - The new SVG parser is more strict about syntax and may fail to load some documents. In such cases the plugin will fall back to using the previous method of loading SVGs to raster images.
+    If your SVGs appear pixelated, check the plugin's log file for warnings about this, and validate/simplify your SVG syntax if you find loading errors.
+  - The new parser may also log warnings about element(s) it doesn't "like" but which don't prevent loading the image. These will show up in the TP log since unfortunately there's no way for us
+    to intercept them. If you see messages like "cannot append child nodes to an SVG shape" being logged, ignore them or check your SVGs.
+- "Draw - Text" action now properly supports `serif`, `sans-serif`, `monospace`, and `system-ui` generic font families. Existing icons which were using generic font names will likely change as a result.
+- Replaced "Tracking" option with "Letter Spacing" on "Draw - Text" action.
+- Improved text rendering and alignment (may have slight alignment differences with some fonts vs. previous version).
+- Converted the layer "position" field in all "Animate & Update" actions to "text" type which allows TP variables to be used.
+- Added "Auto" as a choice for "Draw Direction" setting in "Paths - Add Ellipse / Arc" action. This automatically draws in the counterclockwise direction if the specified ending angle value is lower than the starting angle.
+- A message is now written to the log file whenever deleting an icon instance.
+- Moved the plugin's actions to Touch Portal "Tools" category.
+
+### Fixes
+- Improved stability with multi-layered images to ensure elements are applied in the correct order, especially when using elements like complex paths or generating many images at once.
+  In some (rare) cases the actions could not be parsed in time before the next action's data came in, leading to elements being assigned to the wrong layers.
+- Fixed rendering issues with some combinations of drop-shadow effects and rotation transformations (upstream in `skia-canvas`).
+- Fixed clearing the image cache for an icon instance which shares the cached image with other icon instances but wasn't the first to use that image.
+- Fixed skew transformation not working properly except with very large values (wasn't scaled correctly).
+- Fixed that "Simple Bar Graph" used as a standalone (non-layered) icon didn't respect the default icon size from plugin settings when calculating how many bars can fit on one image.
+- Fixed that "small-caps" font variant was not being respected in the "Draw - Text" action font specification.
+
+### Other Updates
+- Updated `skia-canvas` drawing library to v2.0.2 (includes all related upstream libraries and the underlying _Skia Graphics_ itself).
+- Updated `sharp` image loading and compression library to v0.33.5.
+- Releases now use NodeJS v22 (LTS) runtime, up from v18.
+- Added separate release builds for MacOS Intel (x64) and ARM64 (Mn) architectures.
+
+**Full log:** [v1.2.0-beta1...v1.3.0](https://github.com/spdermn02/TouchPortal-Dynamic-Icons/compare/v1.2.0-beta1...v1.3.0)
+
+[File Output Options]: https://github.com/spdermn02/TouchPortal-Dynamic-Icons/wiki/File-Output-Options
+[Custom Scripts]: https://github.com/spdermn02/TouchPortal-Dynamic-Icons/wiki/Custom-Scripts
+
+---
 ## v1.2.0-beta1 - Path Operations, Dynamic Colors, Enhanced Round Gauge, & More
 
 ### New Features
@@ -39,7 +87,6 @@
 - Concurrent system thread usage changes: ([ee62e201])
   - The number of simultaneous image rendering threads is now set to use half the logical cores available on the host system. Previously this was always fixed to 4 threads.
   - The default number of simultaneous image compression threads has been reduced to using half the logical cores available (controllable via new Setting mentioned above). Previously this used as many threads as there were logical cores.
-- Prevent layer updates while icon is actively rendering (warnings are logged to file). ([ab60b03b])
 - Optimized data transfer between the drawing canvas ('skia-canvas') and final compression step ('sharp') by ~400% using updated custom version of 'skia-canvas' to export raw pixel data. ([cc4717e2], [skia-canvas@8cbc8910])
 - Slightly optimized image file loading (before cache) by creating canvas images using raw pixel data instead of encoded/decoded PNG format. ([72b907d5], [skia-canvas@1e7e09b7])
 - Fixed upstream issue in 'skia-canvas' which sometimes caused full circles to not be drawn at all. ([skia-canvas@bb99a3ad])
@@ -61,7 +108,6 @@
 [e7a467b5]: https://github.com/spdermn02/TouchPortal-Dynamic-Icons/commit/e7a467b55464e098435ba4cfdaa327c8cc3738d8
 [14449c23]: https://github.com/spdermn02/TouchPortal-Dynamic-Icons/commit/14449c23a4165dd15c9d26ba11749ccab48e0858
 [ee62e201]: https://github.com/spdermn02/TouchPortal-Dynamic-Icons/commit/ee62e201f4a87e80e29a2f852da71d81ab19f9aa
-[ab60b03b]: ab60b03b11001ac339e76d02c400fc5f916b2559
 [cc4717e2]: https://github.com/spdermn02/TouchPortal-Dynamic-Icons/commit/cc4717e2de6f0db11c8e4a4acd77b66f0ba173b2
 [72b907d5]: https://github.com/spdermn02/TouchPortal-Dynamic-Icons/commit/72b907d5b63c0817c33e76efe5ec5325b893ec8d
 [4b69a8d9]: https://github.com/spdermn02/TouchPortal-Dynamic-Icons/commit/4b69a8d9533dae7e3fed012a204da8d270277189

--- a/builders/build.js
+++ b/builders/build.js
@@ -67,7 +67,11 @@ const build = async(platform) =>
         process.exit(1)
     }
 
-    if (platform != "win32") {
+    if (platform == "win32") {
+        // We need to copy updated MSVC runtime DLLs into the skia-canvas binary directory to avoid TP's outdated versions being loaded (which crashes the plugin)
+        copyFiles("c:/Windows/System32", "./node_modules/skia-canvas/lib/v8", ["msvcp140.dll", "vcruntime140.dll", "vcruntime140_1.dll"])
+    }
+    else {
         // Copy the startup script
         copyFileSync(`${BASE_SRC}/start.sh`, STAGING)
     }
@@ -118,6 +122,12 @@ const cleanInstallers  = () => {
 
 const copyFileSync = function(filePath, destDir) {
     return fse.copySync(filePath, path.join(destDir, path.basename(filePath)))
+}
+
+function copyFiles(srcDir, destDir, files) {
+    files.map((f) =>
+        fs.copyFileSync(path.join(srcDir, f), path.join(destDir, f))
+    );
 }
 
 const executeBuilds = function() {

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -159,8 +159,20 @@ const entry_base =
             readOnly: false,
             tooltip: {
                 title: cleanSettingTitle(C.SettingName.MaxImageProcThreads),
-                body: "Sets the maximum number of parallel CPU threads used for image compression. A value of \""+C.Str.Default+"\" (or zero) will use half the available CPU threads (usually twice the number of physical CPU cores).\n\n" +
-                    "When specifying a setting, this should be a number between 1 and the maximum number of threads a CPU can process in parallel, which again is usually twice the number of physical CPU cores.",
+                body: "Sets the maximum number of parallel CPU threads used for image compression. A value of \""+C.Str.Default+"\" (or zero) will use half the available CPU threads (modern CPUs can typically run 2 threads per physical CPU core).\n" +
+                    "When specifying a setting, this should be a number between 1 and the maximum number of threads a CPU can process in parallel.",
+                docUrl: `${DOCS_URL_BASE}#plugin-settings`
+            }
+        },
+        {
+            name: C.SettingName.MaxImageGenThreads,
+            type: "text",
+            default: C.Str.Default,
+            readOnly: false,
+            tooltip: {
+                title: cleanSettingTitle(C.SettingName.MaxImageGenThreads),
+                body: "Sets the maximum number of parallel threads used for image generation (rendering). A value of \""+C.Str.Default+"\" (or zero) will use half the available CPU threads (modern CPUs can typically run 2 threads per physical CPU core).\n" +
+                    "When specifying a setting, this should be a number between 1 and the maximum number of threads a CPU can process in parallel.",
                 docUrl: `${DOCS_URL_BASE}#plugin-settings`
             }
         },

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -536,9 +536,9 @@ function makeDrawStyleData(id, /* out */ data, { withShadow=true, fillColor="#00
     return format;
 }
 
-function makeRectSizeData(id, /* out */ data, w = 100, h = 100, label = "Size", wLabel = "W", hLabel = "H") {
+function makeRectSizeData(id, /* out */ data, w = 100, h = 100, label = "Size", wLabel = `${SP_EM}W`, hLabel = "H") {
     let i = data.length;
-    const format = `${label}\n${SP_EM}${wLabel} {${i++}}{${i++}}${NBSP}\n${hLabel} {${i++}}{${i++}}`;
+    const format = `${label}\n${wLabel} {${i++}}{${i++}}${NBSP}\n${hLabel} {${i++}}{${i++}}`;
     data.push(
         makeTextData(jid(id, "size_w"), "Width", w.toString()),
         makeSizeTypeData(jid(id, "size_w")),
@@ -707,7 +707,7 @@ function addProgressBarAction(id, name, subcat) {
     data.push(
         makeChoiceData("pbar_dir", "Direction", ["➡\tL to R", "⬅\tR to L", "⟺\tL & R", "⬆\tB to T", "⬇\tT to B", "↕\tT & B"]),
     );
-    format += makeRectSizeData("pbar", data, 25, 0, "Padding", "Sides", "Ends") + " ";
+    format += makeRectSizeData("pbar", data, 25, 0, "Padding", `${SP_EM}Sides`, "Ends") + " ";
     format += makeBorderRadiusData("pbar", data);
     format += " Container:\n" + makeDrawStyleData("pbar_ctr", data).replace("Fill\n", "");
     format += " Value:\n" + makeDrawStyleData("pbar_val", data, { withShadow: false }).replace("Fill\n", "");
@@ -745,8 +745,10 @@ function addGaugeTicksAction(id, name, subcat, linear = false) {
             makeTextData(jid(id, "start"), "Start Angle", "0"),
             makeTextData(jid(id, "end"), "End Angle", "360"),
         );
-        format += makeRectSizeData(id, data) + " ";
+        format += makeRectSizeData(id, data, 100, 100, "Diam-", `eter H`, "V") + " ";
     }
+    format += `Scale\nto Fit {${data.length}} `;
+    data.push(makeYesNoSwitchData(jid(id, "scaleToFit"), true));
     format += makeAlignmentData(id, data) + " ";
     format += makeOffsetData(id, data) + " ";
     format = [format];

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -617,7 +617,7 @@ function addProgressGaugeAction(id, name, subcat) {
         makeSizeTypeData("gauge_line_width"),
         makeChoiceData("gauge_line_cap", "Gauge Icon Cap Type", ["round", "butt", "square"]),
         makeTextData("gauge_radius", "Diameter", "78"),
-        makeChoiceData("gauge_counterclockwise", "Gauge Direction", ["Clockwise", "Counter CW", "Automatic"]),
+        makeChoiceData("gauge_counterclockwise", "Gauge Direction", C.ARC_DIRECTION_CHOICES),
         makeActionData("gauge_background_color", "color", "Gauge Background Color", "#000000FF"),
         makeActionData("gauge_shadow_color", "color", "Gauge Shadow Color", "#282828FF"),
     );
@@ -689,7 +689,7 @@ function addEllipsePathAction(id, name, subcat) {
     data.push(
         makeTextData(jid(id, "start"), "Start Angle", "0"),
         makeTextData(jid(id, "end"), "End Angle", "360"),
-        makeChoiceData(jid(id, "dir"), "Draw Direction", ["Clockwise", "Counter CW"]),
+        makeChoiceData(jid(id, "dir"), "Draw Direction", C.ARC_DIRECTION_CHOICES),
         makeTextData(jid(id, "rotate"), "rotation Angle", "0"),
     );
     format += makeAlignmentData(id, data) + " ";

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -262,7 +262,7 @@ function makeActionData(id, type, label = "", deflt = "") {
     };
 }
 
-function makeTextData(id, label, dflt = "") {
+function makeTextData(id, label = "", dflt = "") {
     return makeActionData(id, "text", label, dflt + '');
 }
 
@@ -282,6 +282,12 @@ function makeNumericData(id, label, dflt, min, max, allowDec = true) {
     d.allowDecimals = allowDec;
     d.minValue = min;
     d.maxValue = max;
+    return d;
+}
+
+function makeFileData(id, extensions = [], dflt = "") {
+    const d = makeActionData(id, "file", "", dflt);
+    d.extensions = extensions;
     return d;
 }
 
@@ -798,6 +804,20 @@ function addGenerateLayersAction(id, name, subcat) {
     addAction(id, name, descript, format, data, subcat);
 }
 
+function addSaveToFileAction(id, name, subcat) {
+    const descript = "Dynamic Icons: " +
+        "Save the generated image to a file (or multiple files for tiled images). File paths are relative to this plugin's \"Default Image Files Path\" setting, or use absolute paths.\n" +
+        "Extension of the given file name determines the format. Supported: AVIF, GIF, JPEG, PNG, TIFF, & WEBP. Each format accepts different options, see plugin documentation wiki for details.";
+    let [format, data] = makeIconLayerCommonData(id);
+    let i = data.length;
+    format += `save to file {${i++}} with options {${i++}} (name=value, name2=value, ...)`;
+    data.push(
+        makeFileData(jid(id, "file"), ["*.avif", "*.gif", "*.jpg", "*.jpeg", "*.png", "*.tif", "*.tiff", "*.webp"]),
+        makeTextData(jid(id, "options")),
+    );
+    addAction(id, name, descript, format, data, subcat);
+}
+
 // Shared actions for updating existing icons/layers.
 
 function addTransformAction(id, name, subcat, withIndex = false) {
@@ -890,6 +910,7 @@ addTransformAction(      jid(iid, C.Act.IconTx),        "Layer - Add Transformat
 addFilterAction(         jid(iid, C.Act.IconFilter),    "Layer - Set Effect Filter",          ACTION_CATS.layer );
 addCompositeModeAction(  jid(iid, C.Act.IconCompMode),  "Layer - Set Composite Mode",         ACTION_CATS.layer );
 addGenerateLayersAction( jid(iid, C.Act.IconGenerate),  "Layer - Generate Layered Icon",      ACTION_CATS.layer );
+addSaveToFileAction(     jid(iid, C.Act.IconSaveFile),  "Layer - Save Icon To File",          ACTION_CATS.layer );
 addRectanglePathAction(  jid(iid, C.Act.IconRectPath),  "Paths - Add Rounded Rectangle",      ACTION_CATS.paths );
 addEllipsePathAction(    jid(iid, C.Act.IconEllipse),   "Paths - Add Ellipse / Arc",          ACTION_CATS.paths );
 addFreeformPathAction(   jid(iid, C.Act.IconPath),      "Paths - Add Freeform Path",          ACTION_CATS.paths );

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -32,7 +32,7 @@ const C = require("../dist/utils/consts.js");
 var VERSION = pkgConfig.version;
 var BUILD_NUM = pkgConfig.config.build;
 var OUTPUT_PATH = "base"
-var DOCS_URL_BASE = "https://github.com/spdermn02/TouchPortal-Dynamic-Icons/wiki/Documentation";
+var DOCS_URL_BASE = pkgConfig.homepage + "/wiki/Documentation";
 var DEV_MODE = false;
 
 // Handle CLI arguments
@@ -90,6 +90,9 @@ const entry_base =
         colorLight: "#7289DA",
         parentCategory: "misc",
     },
+    settingsDescription: pkgConfig.description + "\n" +
+        "For more details, documentation, and examples please visit the plugin's home page at: " + pkgConfig.homepage + "\n" +
+        "Installed plugin version: " + VERSION,
     settings: [
         {
             name: C.SettingName.IconSize,

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -794,6 +794,20 @@ function addGaugeTicksAction(id, name, subcat, linear = false) {
     addActionV7(id, name, descript, format, data, subcat);
 }
 
+function addScriptAction(id, name, subcat) {
+    const descript = "Run a Custom Script for drawing. Use JavaScript with standard Canvas API & additions. See plugin documentation for details.\n" +
+        "When Cache is On, Script File is only loaded & parsed once, improving efficiency. Arguments will be available in the script as a global 'scriptArgs' string variable.";
+    let [format, data] = makeIconLayerCommonData(id);
+    let i = data.length;
+    format += `Load Script from File {${i++}} with Cache {${i++}} and run with Arguments {${i++}}`;
+    data.push(
+        makeFileData(jid(id, "src"), ["*.js,*.*"]),
+        makeActionData(jid(id, "cache"), "switch", "Cache", true),
+        makeTextData(jid(id, "args")),
+    );
+    addAction(id, name, descript, format, data, subcat, true);
+}
+
 // Paths and path handlers
 
 function addRectanglePathAction(id, name, subcat) {
@@ -989,7 +1003,7 @@ function addTransformUpdtAction(id, name, subcat) { addTransformAction(id, name,
 function addValueUpdateAction(id, name, subcat) {
     const descript = "Dynamic Icons: " +
         "Update a value on an element in an existing icon. " +
-        "Elements which can be updated: Gauge, Graph and Bar values, Text content, Image source, and Effect Filter. " +
+        "Elements which can be updated: Gauge, Graph and Bar values, Text content, Image source, Effect Filter and Script arguments. " +
         "Value type must match the element type (numeric/string), and may contain math and other JS expressions.\n" +
         "Icon with same Name must already exist and contain a supported element type at the specified position. " +
         "Position indexes start at 1 (non-layered icons have only one position). Specify a negative index to count from the bottom of a layer stack.";
@@ -1044,6 +1058,7 @@ addGaugeTicksAction(     jid(iid, C.Act.IconLinearTicks),   "Draw - Linear Tick 
 addTextAction(           jid(iid, C.Act.IconText),      "Draw - Text",                        ACTION_CATS.basic );
 addImageAction(          jid(iid, C.Act.IconImage),     "Draw - Image",                       ACTION_CATS.basic );
 addRectangleAction(      jid(iid, C.Act.IconRect),      "Draw - Styled Rectangle",            ACTION_CATS.basic );
+addScriptAction(         jid(iid, C.Act.IconScript),    "Draw - Run Custom Script",           ACTION_CATS.basic );
 addStartLayersAction(    jid(iid, C.Act.IconDeclare),   "Layer - New Layered Icon",           ACTION_CATS.layer );
 addTransformAction(      jid(iid, C.Act.IconTx),        "Layer - Add Transformation",         ACTION_CATS.layer );
 addFilterAction(         jid(iid, C.Act.IconFilter),    "Layer - Set Effect Filter",          ACTION_CATS.layer );

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -115,23 +115,22 @@ const entry_base =
                 docUrl: `${DOCS_URL_BASE}#plugin-settings`
             }
         },
-        /*  Do not use GPU setting for now, possibly revisit if skia-canvas is fixed. **
         {
             name: C.SettingName.GPU,
-            type: "text",
-            default: PluginSettings.defaultGpuRendering ? "Yes" : "No",
+            type: "switch",
+            default: PluginSettings.defaultGpuRendering ? "on" : "off",
             readOnly: false,
             tooltip: {
                 title: cleanSettingTitle(C.SettingName.GPU),
-                body: "Enables or disables using hardware acceleration (GPU), when available, for generating icon images. One of: \"yes, true, 1, or enable\" to enable, anything else to disable.\n" +
-                    "This setting can be also be overridden per icon. Changing this setting does not affect any icons already generated since the plugin was started.\n\n" +
-                    "When disabled, all image processing happens on the CPU, which may be slower and/or produce slightly different results in some cases.\n\n" +
-                    "GPU rendering is only supported on some hardware/OS/drivers, and is disabled on others regardless of this setting.\n\n" +
-                    "Note that at least some CPU will be used when generating icons in any case, most notably for image file loading and final output PNG compression.",
+                body: "Enables using hardware acceleration (GPU) for generating icon images (on supporrted hardware). " +
+                    "When disabled, all image processing happens on the CPU. Using GPU may provide speed or efficiency benefits in some cases and may produce slightly different visual results.\n\n" +
+                    "This setting can be also be overridden per icon when using layers.\n" +
+                    "GPU rendering is only supported on some hardware/OS/drivers, and is disabled on others regardless of this setting. " +
+                    "Note that at least some CPU will be used when generating icons in any case, most notably for image file loading and final output PNG compression. " +
+                    "Changing this setting will not affect any created icon instances until they're cleared (with \"Delete Icon State\" action) or the plugin is restarted.",
                 docUrl: `${DOCS_URL_BASE}#plugin-settings`
             }
         },
-        */
         {
             name: C.SettingName.PngCompressLevel,
             type: "number",
@@ -756,13 +755,11 @@ function addGenerateLayersAction(id, name, subcat) {
         "'Finalize' marks the icon as finished, removing any extra layers which may have been added previously. 'Render' produces the actual icon in its current state and sends it to TP.";
     let [format, data] = makeIconLayerCommonData(id);
     let i = data.length;
-    format += `{${i++}} with Compression Level {${i++}} (default is set in plugin Settings)`;
-    // Do not use GPU setting for now, possibly revisit if skia-canvas is fixed.
-    // const format = "Icon Named {0} {1} | Enable GPU Rendering: {2} Compression Level: {3} (defaults are set in plugin Settings)";
+    format += `{${i++}} with Compression Level {${i++}} and GPU Rendering {${i++}} (defaults are set in plugin Settings)`;
     data.push(
         makeChoiceData("icon_generate_action", "Action", ["Finalize & Render", "Finalize Only", "Render Only"]),
-        // makeChoiceData("icon_generate_gpu", "Enable GPU Rendering", ["default", "Enable", "Disable"]),
-        makeChoiceData("icon_generate_cl", "Image Compression Level", ["default", "None", "1 (low)", "2", "3", "4", "5", "6", "7", "8", "9 (high)"]),
+        makeChoiceData("icon_generate_cl", "Compression Level", ["default", "None", "1 (low)", "2", "3", "4", "5", "6", "7", "8", "9 (high)"]),
+        makeChoiceData("icon_generate_gpu", "GPU Rendering", ["default", "Enabled", "Disabled"]),
     );
     addAction(id, name, descript, format, data, subcat);
 }

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -276,7 +276,7 @@ function makeIconLayerCommonData(id, withIndex = false) {
     const data = [ makeIconNameData(id) ];
     if (withIndex) {
         format += "Element\n@ Position{1}";
-        data.push(makeNumericData(jid(id, "layer_index"), "Layer Position", 1, -99, 99, false));
+        data.push(makeTextData(jid(id, "layer_index"), "Layer Position", "1"));
     }
     return [ format, data ];
 }

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -89,7 +89,7 @@ const entry_base =
     configuration: {
         colorDark:  "#23272A",
         colorLight: "#7289DA",
-        parentCategory: "misc",
+        parentCategory: "tools",
     },
     settingsDescription: pkgConfig.description + "\n" +
         "For more details, documentation, and examples please visit the plugin's home page at: " + pkgConfig.homepage + "\n" +

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -588,7 +588,7 @@ function addImageAction(id, name, subcat) {
     let i = data.length;
     format += `Image\nFile {${i++}}Resize\nFit {${i++}}`;
     data.push(
-        makeActionData(jid(id, "src"), "file", "Image Source"),
+        makeFileData(jid(id, "src"), ["*.avif", "*.gif", "*.jpg", "*.jpeg", "*.png", "*.svg", "*.tif", "*.tiff", "*.webp"]),
         makeChoiceData(jid(id, "fit"), "Resize Fit", ["contain", "cover", "fill", "scale-down", "none"]),
     );
     format += makeTransformData(C.DEFAULT_TRANSFORM_OP_ORDER.slice(0, 3), jid(id, C.Act.IconTx), data);  // don't include skew op

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -621,20 +621,20 @@ function addRectangleAction(id, name, subcat) {
 function addTextAction(id, name, subcat) {
     const descript = "Dynamic Icons: " +
         `Generate or layer styled text. ${layerInfoText('text')}\n` +
-        "Font is specified like the CSS 'font' shorthand property. Offset is percent of icon size, positive for right/down, negative for left/up. Stroke width in % is based on half the font size.";
+        "Font is specified like the CSS 'font' shorthand property. Set Wrap Width to zero or empty to disable automatic wrapping. Offset is percent of icon size, positive for right/down, negative for left/up. Stroke width in % is based on half the font size.";
     let [format, data] = makeIconLayerCommonData(id);
     let i = data.length;
-    format += `Text {${i++}} Font {${i++}} `;  // Baseline {${i++}}
+    format += `Text {${i++}} Font {${i++}} Letter\nSpacing {${i++}} Wrap\nWidth {${i++}}{${i++}} `;
     data.push(
-        makeActionData("text_str", "text", "Text", ""),
-        makeActionData("text_font", "text", "Font", "1.5em sans-serif"),
-        // makeChoiceData("text_baseline", "Baseline", ["alphabetic", "top", "middle", "bottom", "hanging", "ideographic"]),
+        makeTextData(jid(id, "str"), "Text"),
+        makeTextData(jid(id, "font"), "Font", "10vmin sans-serif"),
+        makeTextData(jid(id, "letterSpacing"), "Letter Spacing", "0px"),
+        makeTextData(jid(id, "size_w"), "Width", "100"),
+        makeSizeTypeData(jid(id, "size_w")),
     );
-    format += makeAlignmentData("text", data)
-    format += makeOffsetData("text", data)
-    format += ` Tracking {${data.length}}`;  // Baseline{${i++}}
-    data.push(makeNumericData("text_tracking", "Tracking", 0, -999999, 999999, true))
-    format += makeDrawStyleData("text", data);
+    format += makeAlignmentData(id, data);
+    format += makeOffsetData(id, data);
+    format += makeDrawStyleData(id, data);
     addAction(id, name, descript, format, data, subcat);
 }
 

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -260,10 +260,6 @@ function makeNumericData(id, label, dflt, min, max, allowDec = true) {
     return d;
 }
 
-function makeIconNameData(id, label = "Icon Name") {
-    return makeTextData(jid(id, "name"), label);
-}
-
 function makeSizeTypeData(id, dflt = undefined) {
     return makeChoiceData(jid(id, "unit"), "Unit", ["%", "px"], dflt);
 }
@@ -273,7 +269,7 @@ function makeSizeTypeData(id, dflt = undefined) {
 
 function makeIconLayerCommonData(id, withIndex = false) {
     let format = "Icon\nName {0}";
-    const data = [ makeIconNameData(id) ];
+    const data = [ makeTextData(jid(id, "name"), "Icon Name") ];
     if (withIndex) {
         format += "Element\n@ Position{1}";
         data.push(makeTextData(jid(id, "layer_index"), "Layer Position", "1"));
@@ -758,15 +754,16 @@ function addGenerateLayersAction(id, name, subcat) {
     const descript = "Dynamic Icons: " +
         "Finalize and/or Render a dynamic image icon which has been created using preceding 'New' and 'Draw/Layer' actions using the same Icon Name.\n" +
         "'Finalize' marks the icon as finished, removing any extra layers which may have been added previously. 'Render' produces the actual icon in its current state and sends it to TP.";
-    const format = "Icon Named {0} {1} with Compression Level {2} (default is set in plugin Settings)";
+    let [format, data] = makeIconLayerCommonData(id);
+    let i = data.length;
+    format += `{${i++}} with Compression Level {${i++}} (default is set in plugin Settings)`;
     // Do not use GPU setting for now, possibly revisit if skia-canvas is fixed.
     // const format = "Icon Named {0} {1} | Enable GPU Rendering: {2} Compression Level: {3} (defaults are set in plugin Settings)";
-    const data = [
-        makeIconNameData(id),
+    data.push(
         makeChoiceData("icon_generate_action", "Action", ["Finalize & Render", "Finalize Only", "Render Only"]),
         // makeChoiceData("icon_generate_gpu", "Enable GPU Rendering", ["default", "Enable", "Disable"]),
         makeChoiceData("icon_generate_cl", "Image Compression Level", ["default", "None", "1 (low)", "2", "3", "4", "5", "6", "7", "8", "9 (high)"]),
-    ];
+    );
     addAction(id, name, descript, format, data, subcat);
 }
 

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -153,6 +153,21 @@ const entry_base =
             }
         },
         {
+            name: C.SettingName.PngQualityLevel,
+            type: "number",
+            default: PluginSettings.defaultOutputQuality.toString(),
+            minValue: 0,
+            maxValue: 100,
+            readOnly: false,
+            tooltip: {
+                title: cleanSettingTitle(C.SettingName.PngQualityLevel),
+                body: "Sets the default image color quality of generated and compressed icons. The final image will have the lowest number of colors needed to achieve the specified quality.\n" +
+                    "The number of colors affects the final image data size which will be sent to the TP device for display. Using fewer colors produces smaller images, but possibly at the expense of image quality.\n" +
+                    "This option can be also be overridden per icon when using layers. It has no effect on icons generated with compression disabled entirely.",
+                docUrl: `${DOCS_URL_BASE}#plugin-settings`
+            }
+        },
+        {
             name: C.SettingName.MaxImageProcThreads,
             type: "text",
             default: C.Str.Default,
@@ -772,11 +787,13 @@ function addGenerateLayersAction(id, name, subcat) {
         "'Finalize' marks the icon as finished, removing any extra layers which may have been added previously. 'Render' produces the actual icon in its current state and sends it to TP.";
     let [format, data] = makeIconLayerCommonData(id);
     let i = data.length;
-    format += `{${i++}} with Compression Level {${i++}} and GPU Rendering {${i++}} (defaults are set in plugin Settings)`;
+    format += `{${i++}} with Compression Level {${i++}} Quality {${i++}} and GPU Rendering {${i++}} (defaults are set in plugin Settings)`;
     data.push(
-        makeChoiceData("icon_generate_action", "Action", ["Finalize & Render", "Finalize Only", "Render Only"]),
-        makeChoiceData("icon_generate_cl", "Compression Level", ["default", "None", "1 (low)", "2", "3", "4", "5", "6", "7", "8", "9 (high)"]),
-        makeChoiceData("icon_generate_gpu", "GPU Rendering", ["default", "Enabled", "Disabled"]),
+        makeChoiceData(jid(id, "action"), "Action", ["Finalize & Render", "Finalize Only", "Render Only"]),
+        makeChoiceData(jid(id, "cl"), "Compression Level", [C.Str.Default, "None", "1 (low)", "2", "3", "4", "5", "6", "7", "8", "9 (high)"]),
+        // makeTextData(jid(id, "quality"), "Quality", "100"),
+        makeChoiceData(jid(id, "quality"), "Quality", [C.Str.Default, ...Array.from( {length: 100}, (_, i) => (i+1).toString()).reverse() ]),
+        makeChoiceData(jid(id, "gpu"), "GPU Rendering", [C.Str.Default, "Enabled", "Disabled"]),
     );
     addAction(id, name, descript, format, data, subcat);
 }

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -118,6 +118,7 @@ const entry_base =
                 docUrl: `${DOCS_URL_BASE}#plugin-settings`
             }
         },
+        /* Disable GPU option for now, revisit later if GPU usage becomes stable.
         {
             name: C.SettingName.GPU,
             type: "switch",
@@ -134,6 +135,7 @@ const entry_base =
                 docUrl: `${DOCS_URL_BASE}#plugin-settings`
             }
         },
+        */
         {
             name: C.SettingName.PngCompressLevel,
             type: "number",
@@ -793,13 +795,14 @@ function addGenerateLayersAction(id, name, subcat) {
         "'Finalize' marks the icon as finished, removing any extra layers which may have been added previously. 'Render' produces the actual icon in its current state and sends it to TP.";
     let [format, data] = makeIconLayerCommonData(id);
     let i = data.length;
-    format += `{${i++}} with Compression Level {${i++}} Quality {${i++}} and GPU Rendering {${i++}} (defaults are set in plugin Settings)`;
+    format += `{${i++}} with Compression Level {${i++}} and Quality {${i++}} (defaults are set in plugin Settings)`;
+    // Disable GPU option for now, revisit later if GPU usage becomes stable.
+    // format += `{${i++}} with Compression Level {${i++}} Quality {${i++}} and GPU Rendering {${i++}} (defaults are set in plugin Settings)`;
     data.push(
         makeChoiceData(jid(id, "action"), "Action", ["Finalize & Render", "Finalize Only", "Render Only"]),
         makeChoiceData(jid(id, "cl"), "Compression Level", [C.Str.Default, "None", "1 (low)", "2", "3", "4", "5", "6", "7", "8", "9 (high)"]),
-        // makeTextData(jid(id, "quality"), "Quality", "100"),
         makeChoiceData(jid(id, "quality"), "Quality", [C.Str.Default, ...Array.from( {length: 100}, (_, i) => (i+1).toString()).reverse() ]),
-        makeChoiceData(jid(id, "gpu"), "GPU Rendering", [C.Str.Default, "Enabled", "Disabled"]),
+        // makeChoiceData(jid(id, "gpu"), "GPU Rendering", [C.Str.Default, "Enabled", "Disabled"]),
     );
     addAction(id, name, descript, format, data, subcat);
 }

--- a/builders/gen_entry.js
+++ b/builders/gen_entry.js
@@ -342,6 +342,14 @@ function makeFileData(id, extensions = [], dflt = "") {
     return d;
 }
 
+function makeOnOffSwitchData(id, dflt = true) {
+    return makeChoiceData(id, "", [C.DataValue.OnValue, C.DataValue.OffValue], dflt ? 0 : 1);
+}
+
+function makeYesNoSwitchData(id, dflt = true) {
+    return makeChoiceData(id, "", [C.DataValue.YesValue, C.DataValue.NoValue], dflt ? 0 : 1);
+}
+
 // Specific action data types
 
 function makeSizeTypeData(id, dflt = undefined) {
@@ -349,7 +357,7 @@ function makeSizeTypeData(id, dflt = undefined) {
 }
 
 function makeRenderChoiceData(id) {
-    return makeChoiceData(jid(id, "render"), "Render?", [C.DataValue.NoValue, C.DataValue.YesValue]);
+    return makeYesNoSwitchData(jid(id, "render"), false);
 }
 
 // Shared functions which create both a format string and data array.
@@ -659,7 +667,7 @@ function addProgressGaugeAction(id, name, subcat) {
         `background\n${SP_EM}${SP_EM}${SP_EM}color {${i++}} shadow\n${SP_EM}color {${i++}}`;
     data.push(
         makeActionData("gauge_color", "color", "Gauge Color", "#FFA500FF"),
-        makeChoiceData("gauge_highlight", "Gauge Highlight", ["On", "Off"]),
+        makeOnOffSwitchData("gauge_highlight"),
         makeTextData("gauge_start_degree", "Gauge Start Degree", "180"),
         makeActionData("gauge_value", "text", "Gauge Value", "0"),
         makeTextData("gauge_line_width", "Line Width", "12"),
@@ -680,7 +688,7 @@ function addBarGraphAction(id, name, subcat) {
     let i = data.length;
     format += `with background {${i++}} of color {${i++}} using bar color {${i++}} add value {${i++}} with bar width {${i++}}`;
     data.push(
-        makeChoiceData("bar_graph_backround", "Bar Graph Background", ["On", "Off"]),
+        makeOnOffSwitchData("bar_graph_backround"),
         makeActionData("bar_graph_backround_color", "color", "Bar Graph Background Color", "#FFFFFFFF"),
         makeActionData("bar_graph_color", "color", "Bar Graph Color", "#FFA500FF"),
         makeActionData("bar_graph_value", "text", "Bar Graph Value", "0"),
@@ -802,7 +810,7 @@ function addScriptAction(id, name, subcat) {
     format += `Load Script from File {${i++}} with Cache {${i++}} and run with Arguments {${i++}}`;
     data.push(
         makeFileData(jid(id, "src"), ["*.js,*.*"]),
-        makeActionData(jid(id, "cache"), "switch", "Cache", true),
+        makeOnOffSwitchData(jid(id, "cache")),
         makeTextData(jid(id, "args")),
     );
     addAction(id, name, descript, format, data, subcat, true);
@@ -858,7 +866,7 @@ function addFreeformPathAction(id, name, subcat) {
     data.push(
         makeTextData(jid(id, "path"), "Coordinate List", "[0, 0] [50, 50], [100, 0]"),
         makeSizeTypeData(id),
-        makeChoiceData(jid(id, "close"), "Close Path", [C.DataValue.NoValue, C.DataValue.YesValue]),
+        makeYesNoSwitchData(jid(id, "close"), false),
     );
     format += makeAlignmentData(id, data) + " ";
     format += makeOffsetData(id, data) + " ";

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,3 @@
+dist/
+html/
+*.d.ts

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,12 @@
+## Dynamic Icons Documentation Generator
+
+This folder contains configurations and scripts for generating DI reference documentation and definitions.
+
+Documentation is published at https://spdermn02.github.io/TouchPortal-Dynamic-Icons
+
+Running the generators requires the following modules which are _not_ installed with this project by default:
+```
+    "dts-bundle-generator": "^9.5.0",
+    "typedoc": "^0.2.0"
+```
+Install them manually, either globally or as a temporary package dependency.

--- a/doc/build.js
+++ b/doc/build.js
@@ -1,0 +1,84 @@
+/*
+This script runs typedoc to build reference docs (into "html" subfolder, by default)
+and definitions for dts-bundle-generator (into "dist" subfolder),
+which is then also executed. That bundle output is cleaned up with a bunch of replacements
+and the result written out to "dynamic-icons.d.ts" which is suitable for
+referencing in custom drawing scripts (eg. with "triple slash directive").
+A bit convoluted really, but "best" workflow I've found so far with least manual intervention.
+
+usage: node doc/build.js [-dts <path_to_defintions_output>] [-html <path_to_html_output>
+
+By default the final definitions file is placed in the same folder as the HTML documentation (for download)
+but this can be overridden with the `-dts` option.
+
+Running the generators requires the following modules which are _not_ installed with this project by default:
+
+    "dts-bundle-generator": "^9.5.0",
+    "typedoc": "^0.2.0"
+
+Install them manually, either globally or as a temporary package dev dependency.
+*/
+
+
+const
+    fs = require("fs"),
+    path = require("path"),
+    process = require("process"),
+    { execSync } = require("child_process")
+;
+
+process.env.NPM_CONFIG_UPDATE_NOTIFIER = "false";
+
+const ROOT = "./doc",
+    IN_DTS = "dts-definitions.d.ts",
+    OUT_DTS = "dynamic-icons.d.ts";
+
+// options
+var
+    HTML_OUT_PATH = path.join(ROOT, 'html'),
+    DTS_OUT_PATH = "",
+    runDocs = true,
+    runDefs = true;
+;
+
+// Handle CLI arguments
+for (let i=2; i < process.argv.length; ++i) {
+    const arg = process.argv[i];
+    if      (arg == "-dts")  DTS_OUT_PATH = process.argv[++i];
+    else if (arg == "-html") HTML_OUT_PATH = process.argv[++i];
+    else if (arg == "-nodoc") runDocs = false;
+    else if (arg == "-nodef") runDefs = false;
+}
+
+if (!DTS_OUT_PATH)
+    DTS_OUT_PATH = HTML_OUT_PATH;
+
+// run doc generator
+if (runDocs) {
+    execSync(`npx typedoc --options ${ROOT}/typedoc.json --logLevel Error --html ${HTML_OUT_PATH}`);
+    console.info("Finished generating documentation.");
+}
+
+if (!runDefs)
+    return;
+
+// run bundle generator
+execSync(`npx dts-bundle-generator --config ${ROOT}/dts-bundle.json`);
+
+// clean up/modify generated bundle
+dts = fs.readFileSync(path.join(ROOT, IN_DTS), 'utf-8');
+dts = dts.replace(/\$1/g, "");
+dts = dts.replace(/ as [A-Z]\w+/g, "");
+dts = dts.replace(/ as (?:loadImage(?:Data)?|sharp)/g, "");
+dts = dts.replace("import { EventEmitter } from 'stream';\n", "");
+dts = dts.replace("import sharp from 'sharp';\n", "");
+dts = dts.replace(/declare module "skia-canvas" {\n\t(.+?)^}/ms, "export $1");
+// exclude default lib.dom.d.ts definitions for consumers so that our Canvas definitions override them
+dts = `/// <reference no-default-lib="true"/>
+/// <reference lib="es2022" />
+/// <reference types="node" />
+
+` + dts;
+
+fs.writeFileSync(path.join(DTS_OUT_PATH, OUT_DTS), dts, 'utf-8');
+console.info("Wrote definitions output to %s", path.join(DTS_OUT_PATH, OUT_DTS));

--- a/doc/dts-bundle.json
+++ b/doc/dts-bundle.json
@@ -1,0 +1,20 @@
+{
+    "compilationOptions": {
+        "preferredConfigPath": "./dts-tsconfig.json"
+    },
+    "entries": [
+        {
+            "filePath": "./dts-definitions.ts",
+            "noCheck": true,
+            "libraries": {
+                "inlinedLibraries": ["skia-canvas"]
+            },
+            "output": {
+                "inlineDeclareGlobals": true,
+                "inlineDeclareExternals": true,
+                "exportReferencedTypes": false,
+                "noBanner": true
+            }
+        }
+    ]
+}

--- a/doc/dts-definitions.ts
+++ b/doc/dts-definitions.ts
@@ -1,0 +1,126 @@
+/// <reference lib="es2022" />
+// @ts-ignore
+
+// These definitions are set up for feeding to dts-bundle-generator and actually parses the
+// definitions created by `typedoc`, which needs to be run first and creates a definitions build in ./docs/dist/src
+// (in addition to the actual HTML docs).
+// The dts-bundle-generator output still needs some adjustments to make it work correctly (see ./docs/build.js).
+// Definitely room for improvement of the process since there is a lot of redundancy between this and the `typedoc-definitions.ts` version.
+
+// First export everything as direct exports in the generated bundle
+
+export type * from './dist/src/modules/geometry';
+export type * from './dist/src/modules/elements';
+export type * from './dist/src/modules/enums';
+export type * from 'skia-canvas';
+export type * from './dist/src/utils/extensions';
+export type { DynamicIcon } from './dist/src/modules';
+export type { Logger } from './dist/src/modules/logging';
+// export type * from './dist/src/utils';
+// export type * from './dist/src/modules/types';
+// export type { PngOptions } from 'sharp';
+
+// Then export some of those types again but within a namespace, which are used as references in the globals declaration
+
+export type * as geometry from './dist/src/modules/geometry';
+export type * as elements from './dist/src/modules/elements';
+export type * as enums from './dist/src/modules/enums';
+export type * as utils from './dist/src/utils';
+export type * as canvas from 'skia-canvas';
+
+// Now we need to import the types we're then aliasing in globals. The "as" namespaces must match the exported ones above.
+
+import type * as geometry from './dist/src/modules/geometry';
+import type * as elements from './dist/src/modules/elements';
+import type * as enums from './dist/src/modules/enums';
+import type * as utils from './dist/src/utils';
+import type * as canvas from 'skia-canvas';
+import type { DynamicIcon } from './dist/src/modules';
+import type { Logger } from './dist/src/modules/logging';
+
+/** Additional global scope variables, classes, and utility functions which are available in the scripting environment. */
+declare global {
+    /** The canvas context to draw into. */
+    var canvasContext: canvas.CanvasRenderingContext2D;
+    /** A class representing a rectangle with `x`, `y`, `width`, & `height` properties describing the area to draw into.
+        This is typically the same width & height as the main icon instance, with `x` and `y` both `0`. */
+    var paintRectangle: geometry.Rectangle;
+    /** Argument string specified in the "Run Custom Script" action's "Arguments" field or via "Update Value" action. */
+    var scriptArgs: string;
+    /** A class representing the current icon instance that is running this script.
+        It has useful properties such as `iconName`, `width` & `height`. */
+    var parentIcon: DynamicIcon;
+    /** A class for writing output to the Dynamic Icons plugin log file. Has `debug()`, `info()`, `warn()`, `error()` and `trace()` methods,
+        which are equivalent to their `console` counterparts. */
+    var logger: Logger;
+
+    /** The `DI` namespace object contains static utility functions, enumerations, and constructors for custom Dynamic Icons elements. */
+    const DI: typeof elements & typeof utils & typeof enums;
+
+    // We have to include aliases for both the implementation and type of each class in the global scope,
+    // otherwise apparently either one or the other isn't propertly recognized as being global (at leat in VSCode).
+
+    const Point: typeof geometry.Point;
+    const Rectangle: typeof geometry.Rectangle;
+    const Size: typeof geometry.Size;
+    const UnitValue: typeof geometry.UnitValue;
+    const Vect2d: typeof geometry.Vect2d;
+
+    const Canvas: typeof canvas.Canvas;
+    const DOMMatrix: typeof canvas.DOMMatrix;
+    const DOMPoint: typeof canvas.DOMPoint;
+    const DOMRect: typeof canvas.DOMRect;
+    const Image: typeof canvas.Image;
+    const ImageData: typeof canvas.ImageData;
+    const Path2D: typeof canvas.Path2D;
+    const loadImage: typeof canvas.loadImage;
+    const loadImageData: typeof canvas.loadImageData;
+
+    // Some other aliases are already declared in global scope from our ./src/module/types.ts
+    type Rectangle = geometry.Rectangle;
+    type Size = geometry.Size;
+    type UnitValue = geometry.UnitValue;
+    type Vect2d = geometry.Vect2d;
+
+    type Canvas = canvas.Canvas;
+    type DOMMatrix = canvas.DOMMatrix;
+    type DOMPoint = canvas.DOMPoint;
+    type DOMRect = canvas.DOMRect;
+    type Image = canvas.Image;
+    type ImageData = canvas.ImageData;
+    type Path2D = canvas.Path2D;
+}
+
+
+// Include `sharp.PngOptions` here instead of re-exporting from sharp... it's simpler and we have custom defaults anyway.
+/** Image compression options to use when rendering icon images for final output to Touch Portal.
+
+    Default `compressionLevel` and `quality` are set in plugin settings and can be overridden in an icon's "finalize" action.
+    `compressionLevel` of `0` disables compression step entirely (`sharp` lib is never invoked, `skia-canvas` PNG-24 output is used directly).
+    Otherwise these are passed to [`sharp.png()`](https://sharp.pixelplumbing.com/api-output#png) for final compression of the `skia-canvas` output.
+    Default `effort` is set to `1` and `palette` to `true`.
+*/
+export namespace sharp {
+    export interface PngOptions {
+        /** Force format output, otherwise attempt to use input format (optional, default true) */
+        force?: boolean | undefined;
+        /** Use progressive (interlace) scan (optional, default false) */
+        progressive?: boolean | undefined;
+        /** zlib compression level, 0-9 (optional, default 6) */
+        compressionLevel?: number | undefined;
+        /** Use adaptive row filtering (optional, default false) */
+        adaptiveFiltering?: boolean | undefined;
+        /** Use the lowest number of colours needed to achieve given quality (optional, default `100`) */
+        quality?: number | undefined;
+        /** Level of CPU effort to reduce file size, between 1 (fastest) and 10 (slowest), sets palette to true (optional, default 7) */
+        effort?: number | undefined;
+        /** Quantise to a palette-based image with alpha transparency support (optional, default false) */
+        palette?: boolean | undefined;
+        /** Maximum number of palette entries (optional, default 256) */
+        colours?: number | undefined;
+        /** Alternative Spelling of "colours". Maximum number of palette entries (optional, default 256) */
+        colors?: number | undefined;
+        /**  Level of Floyd-Steinberg error diffusion (optional, default 1.0) */
+        dither?: number | undefined;
+    }
+}

--- a/doc/dts-tsconfig.json
+++ b/doc/dts-tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "typeRoots": [],
+    "noCheck": true,
+    "noEmit": true,
+    "removeComments": false,
+    "rootDir": "./",
+    "skipLibCheck": true,
+    "sourceMap": false
+  },
+  "include": [
+    "dist/src/**/*"
+  ],
+  "exclude": []
+}

--- a/doc/typedoc-definitions.ts
+++ b/doc/typedoc-definitions.ts
@@ -1,0 +1,205 @@
+/**
+@packageDocumentation
+Reference documentation for the Touch Portal Dynamic Icons Plugin scripting environment available with the
+["Run Custom Script"](https://github.com/spdermn02/TouchPortal-Dynamic-Icons/wiki/Custom-Scripts) action.
+
+Note that everything described here as being in the {@link global} "Variable" is actually just in the global scope of the scripting environment.
+Those variables and classes are available directly, w/out needing any import or prefix.
+
+All the other types listed on this page are available either directly in the global scope or from the global {@link DI} namespace object.
+See the {@link global} reference for details.
+
+The `skia-canvas` module summary is included here for quick reference, but for complete documentation see {@link http://skia-canvas.org/api}.
+
+An exported [definitions file](./dynamic-icons.d.ts) is available to provide code hinting in compatible editors (such as `VSCode`).
+The defintions describe everything available in the global scope, all *skia-canvas* types, and all custom types from this reference.
+
+Place this file somewhere "close" to your scripts and reference it using a "triple slash directive" at the top of your script, including a relative path.
+For example, if the declarations file is in the same folder as your script:
+```js
+/// <reference path="./dynamic-icons.d.ts"/>
+```
+*/
+
+// These definitions are set up for feeding to `typedoc` and focus on just the types available in the public scripting environment.
+// Typedoc should be run from the project root with:
+//   typedoc --options ./doc/typedoc.json
+//
+// Note: the `global` "variable" declared here is actually the global scope, but there doesn't seem to be a way to document that with Typedoc.
+//
+// TODO: could probably generate a lot of this instead of creating manually.
+
+
+export type * from '../src/modules/geometry';
+// export type * as geometry from '../src/modules/geometry';
+export type * from '../src/modules/elements';
+// export type * as elements from '../src/modules/elements';
+export type * from '../src/modules/enums';
+// export type * as enums from '../src/modules/enums';
+export type * from '../src/utils/helpers';
+export type * from '../src/utils/drawing';
+// export * from '../src/utils';
+// export type * as utils from '../src/utils';
+export type * as canvas from 'skia-canvas';
+export type * from '../src/utils/extensions';
+export type { types } from '../src/modules/types';
+export type { DynamicIcon } from '../src/modules';
+export type { Logger } from '../src/modules/logging';
+
+import type * as geometry from '../src/modules/geometry';
+import type * as elements from '../src/modules/elements';
+import type * as utils from '../src/utils';
+import type * as canvas from 'skia-canvas';
+import type { DynamicIcon } from '../src/modules';
+import type { Logger } from '../src/modules/logging';
+
+/** Additional global scope variables, classes, and utility functions which are available in the scripting environment.
+
+    Although `global` is described here as a "variable" type, it is really the global _scope_ which is documented. No prefix or import
+    is required to use these variables/types.
+
+    The documentation here just provides links to the actual type references (also found in the left navigation bar).
+    Click on the types (on right side) for full details.
+*/
+export declare var global: {
+    /** The canvas context to draw into. */
+    canvasContext: canvas.CanvasRenderingContext2D
+    /** A class representing a rectangle with `x`, `y`, `width`, & `height` properties describing the area to draw into.
+        This is typically the same width & height as the main icon instance, with `x` and `y` both `0`. */
+    paintRectangle: geometry.Rectangle
+    /** Argument string specified in the "Run Custom Script" action's "Arguments" field or via "Update Value" action. */
+    scriptArgs: string
+    /** A class representing the current icon instance that is running this script. It has useful properties such as `name`, `width` & `height`. */
+    parentIcon: DynamicIcon
+    /** A class for writing output to the Dynamic Icons plugin log file. */
+    logger: Logger
+
+    /** The `DI` namespace object contains static utility functions, enumerations, and constructors for custom Dynamic Icons elements. See {@link DI} for details.  */
+    DI: DI
+
+    Point: typeof geometry.Point
+    Rectangle: geometry.Rectangle
+    Size: geometry.Size
+    Vect2d: geometry.Vect2d
+
+    Canvas: canvas.Canvas
+    DOMMatrix: canvas.DOMMatrix
+    DOMPoint: canvas.DOMPoint
+    DOMRect: canvas.DOMRect
+    Image: canvas.Image
+    ImageData: canvas.ImageData
+    Path2D: canvas.Path2D
+    loadImage: typeof canvas.loadImage
+    loadImageData: typeof canvas.loadImageData
+
+}
+
+// Would be nice to present Point as an interface instead of a variable, but no joy.
+// type PointT = typeof geometry.Point;
+// export interface Point extends PointT {}
+// export var Point: typeof geometry.Point;
+
+/** The `DI` namespace object contains static utility functions, enumerations, and constructors for custom Dynamic Icons elements.
+
+    Note: enumerations are not listed here, refer to the main index page or navigation tree for listing.
+
+    To use any of these classes, functions, or enums, prefix them with `DI` (similar to how `Math` works). For example:
+    ```js
+        let c = DI.round4p(Math.cos(angle));
+        const textElement = new DI.StyledText({ text: "Hello World!", alignment: DI.Alignment.TopCenter });
+    ```
+    The documentation here just provides links to the actual class/function references (also found in the left navigation bar).
+    Click on the types (on right side) for full details.
+*/
+export declare const DI: {
+        BarGraph: elements.BarGraph,
+        BrushStyle: elements.BrushStyle,
+        // CanvasFilter: elements.CanvasFilter,  // not needed in scripts
+        CircularTicks: elements.CircularTicks,
+        // ClippingMask: elements.ClippingMask,  // not needed in scripts
+        // CompositionMode: elements.CompositionMode,  // not needed in scripts
+        DrawingStyle: elements.DrawingStyle,
+        DynamicImage: elements.DynamicImage,
+        EllipsePath: elements.EllipsePath,
+        FreeformPath: elements.FreeformPath,
+        // GaugeTicks: elements.GaugeTicks,  // not creatable
+        LinearProgressBar: elements.LinearProgressBar,
+        LinearTicks: elements.LinearTicks,
+        // Path: elements.Path,  // not creatable
+        RectanglePath: elements.RectanglePath,
+        RoundProgressGauge: elements.RoundProgressGauge,
+        // Script: elements.Script,  // not needed from within other scripts
+        ShadowStyle: elements.ShadowStyle,
+        // SizedElement: elements.SizedElement,  // not creatable
+        StrokeStyle: elements.StrokeStyle,
+        StyledRectangle: elements.StyledRectangle,
+        StyledText: elements.StyledText,
+        Transformation: elements.Transformation,
+
+        arraysMatchExactly: typeof utils.arraysMatchExactly,
+        assignExistingProperties: typeof utils.assignExistingProperties,
+        circularLabelsPath: typeof utils.circularLabelsPath,
+        cirularGaugeTicksPath: typeof utils.cirularGaugeTicksPath,
+        clamp: typeof utils.clamp,
+        elideLeft: typeof utils.elideLeft,
+        elideRight: typeof utils.elideRight,
+        evaluateStringValue: typeof utils.evaluateStringValue,
+        evaluateValue: typeof utils.evaluateValue,
+        evaluateValueAsArray: typeof utils.evaluateValueAsArray,
+        fuzzyEquals: typeof utils.fuzzyEquals,
+        fuzzyEquals3p: typeof utils.fuzzyEquals3p,
+        fuzzyEquals4p: typeof utils.fuzzyEquals4p,
+        fuzzyEquals5p: typeof utils.fuzzyEquals5p,
+        fuzzyEquals6p: typeof utils.fuzzyEquals6p,
+        linearGaugeTicksPath: typeof utils.linearGaugeTicksPath,
+        linearLabelsPath: typeof utils.linearLabelsPath,
+        normalizeAngle: typeof utils.normalizeAngle,
+        parseAlignmentFromValue: typeof utils.parseAlignmentFromValue,
+        parseAlignmentsFromString: typeof utils.parseAlignmentsFromString,
+        parseArcDirection: typeof utils.parseArcDirection,
+        parseBoolFromValue: typeof utils.parseBoolFromValue,
+        parseBoolOrDefault: typeof utils.parseBoolOrDefault,
+        parseIntOrDefault: typeof utils.parseIntOrDefault,
+        parseNumericArrayString: typeof utils.parseNumericArrayString,
+        parsePlacement: typeof utils.parsePlacement,
+        parsePointFromValue: typeof utils.parsePointFromValue,
+        qualifyFilepath: typeof utils.qualifyFilepath,
+        round2p: typeof utils.round2p,
+        round3p: typeof utils.round3p,
+        round4p: typeof utils.round4p,
+        round5p: typeof utils.round5p,
+        round6p: typeof utils.round6p,
+    }
+
+// this is for the 'global' variable to reference, don't export
+declare interface DI {}
+
+/** Image compression options to use when rendering icon images for final output to Touch Portal.
+
+    Default `compressionLevel` and `quality` are set in plugin settings and can be overridden in an icon's "finalize" action.
+    `compressionLevel` of `0` disables compression step entirely (`sharp` lib is never invoked, `skia-canvas` PNG-24 output is used directly).
+    Otherwise these are passed to [`sharp.png()`](https://sharp.pixelplumbing.com/api-output#png) for final compression of the `skia-canvas` output.
+    Default `effort` is set to `1` and `palette` to `true`.
+*/
+export type PngOptions = {
+    /** Force format output, otherwise attempt to use input format (optional, default true) */
+    force?: boolean | undefined;
+    /** Use progressive (interlace) scan (optional, default false) */
+    progressive?: boolean | undefined;
+    /** zlib compression level, 0-9 (optional, default 6) */
+    compressionLevel?: number | undefined;
+    /** Use adaptive row filtering (optional, default false) */
+    adaptiveFiltering?: boolean | undefined;
+    /** Use the lowest number of colours needed to achieve given quality (optional, default `100`) */
+    quality?: number | undefined;
+    /** Level of CPU effort to reduce file size, between 1 (fastest) and 10 (slowest), sets palette to true (optional, default 7) */
+    effort?: number | undefined;
+    /** Quantize to a palette-based image with alpha transparency support (optional, default false) */
+    palette?: boolean | undefined;
+    /** Maximum number of palette entries (optional, default 256) */
+    colours?: number | undefined;
+    /** Alternative Spelling of "colours". Maximum number of palette entries (optional, default 256) */
+    colors?: number | undefined;
+    /**  Level of Floyd-Steinberg error diffusion (optional, default 1.0) */
+    dither?: number | undefined;
+}

--- a/doc/typedoc-tsconfig.json
+++ b/doc/typedoc-tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": false,
+    "esModuleInterop": true,
+    "noCheck": true,
+    // "noEmit": true,
+    "emitDeclarationOnly": true,
+    "noImplicitAny": false,
+    "outDir": "./dist",
+    "preserveConstEnums": true,
+    "removeComments": false,
+    "rootDir": "../",
+    "skipLibCheck": true,
+    "sourceMap": false
+  },
+  "include": [
+    "./typedoc-definitions.ts",
+    "../src/**/*"
+  ],
+  "exclude": []
+}

--- a/doc/typedoc.json
+++ b/doc/typedoc.json
@@ -1,0 +1,136 @@
+// TypeDoc config file: https://typedoc.org/documents/Options.html
+{
+  // Configuration
+  "tsconfig": "./typedoc-tsconfig.json",
+  // "compilerOptions": { },
+  "plugin": [
+    // "typedoc-material-theme"
+    // "typedoc-plugin-markdown"
+  ],
+
+  // Input
+  "name": "Dynamic Icons Scripting Reference",
+  // "entryPointStrategy": "expand",
+  "entryPoints": [
+    "./typedoc-definitions.ts"
+    // "src/modules/",
+    // "src/modules/enums.ts",
+    // "src/modules/interfaces.ts",
+    // "src/modules/types.ts",
+    // "src/modules/elements",
+    // "src/modules/geometry",
+    // "src/modules/DynamicIcon.ts",
+    // "src/utils",
+    // "src/utils/extensions.ts"
+  ],
+  // "exclude": [ "../src/utils/consts.ts" ],
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "excludeReferences": true,
+  "excludeNotDocumented": true,
+  "excludeNotDocumentedKinds": [
+    // "Module",
+    // "Namespace",
+    // "Enum",
+    "Variable",
+    // "Function",
+    "Class",
+    // "Interface",
+    // "Constructor",
+    // "Property",
+    // "Method",
+    // "CallSignature",
+    // "IndexSignature",
+    // "ConstructorSignature",
+    // "Accessor",
+    // "GetSignature",
+    // "SetSignature",
+    // "TypeAlias",
+    // "Reference"
+  ],
+  "alwaysCreateEntryPointModule": false,
+  "disableSources": true,
+  "disableGit": true,
+  "includeVersion": true,
+  "readme": "none",
+  // "readme": "../../TouchPortal-Dynamic-Icons.wiki/Custom-Scripts.md",
+
+  // Output
+  "emit": "both",
+  "navigation": {
+    "compactFolders": true,
+    "excludeReferences": false,
+    "includeCategories": true,
+    "includeFolders": false,
+    "includeGroups": true
+  },
+  "visibilityFilters": {
+    "protected": false,
+    "private": false,
+    "inherited": true,
+    "external": true
+  },
+  "hostedBaseUrl": "https://spdermn02.github.io/TouchPortal-Dynamic-Icons",
+  "hideGenerator": true,
+  "markdownLinkExternal": true,
+  "useFirstParagraphOfCommentAsSummary": true,
+  "navigationLinks": {
+    "GitHub": "https://github.com/spdermn02/TouchPortal-Dynamic-Icons",
+    "Wiki": "https://github.com/spdermn02/TouchPortal-Dynamic-Icons/wiki",
+  },
+  "outputs": [
+    {
+      "name": "html",
+      "path": "./html",
+      "options": {
+        "githubPages": true
+      }
+    },
+    // {
+    //   "name": "json",
+    //   "path": "./docs.json"
+    // },
+    // {
+    //   // requires typedoc-plugin-markdown
+    //   "name": "markdown",
+    //   "path": "./md"
+    // }
+  ],
+  // "theme": "material",
+  // "themeColor": "#000000",
+
+  // Organization
+  "groupReferencesByType": true,
+  "groupOrder": [
+    "Variables",
+    "Interfaces",
+    "Classes",
+    "Functions",
+    "Type Aliases",
+    "Enumerations",
+    "Modules",
+    "*"
+  ],
+  "sort": [
+    "kind",
+    "instance-first",
+    // "enum-value-ascending",
+    "visibility",
+    "source-order"
+    // "alphabetical-ignoring-documents"
+  ],
+  "sortEntryPoints": true,
+
+  // Validation
+  "validation": {
+    "notExported": true,
+    "invalidLink": true,
+    "rewrittenLink": false,
+    "notDocumented": false,
+    "unusedMergeModuleWith": true
+  },
+
+  // Other
+  "skipErrorChecking": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "touchportal-dynamic-icons",
-  "version": "1.2.0-beta1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "touchportal-dynamic-icons",
-      "version": "1.2.0-beta1",
+      "version": "1.3.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "async-mutex": "^0.5",
         "sharp": "^0.33.5",
         "skia-canvas": "2.0.2",
         "touchportal-api": "github:spdermn02/touchportal-node-api#master"
@@ -22,20 +22,21 @@
         "adm-zip": "^0.5",
         "eslint": "^9",
         "fs-extra": "^11",
+        "patch-package": "^8.0.0",
         "pkg": "npm:@yao-pkg/pkg@^6.3",
         "ts-node": "^10.9",
         "typescript": "^5.8"
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
+      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0",
+        "@babel/parser": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -45,9 +46,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -55,9 +56,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -65,13 +66,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
+      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.27.1"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -81,14 +82,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -119,9 +120,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -129,9 +130,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -158,9 +159,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -197,9 +198,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
-      "integrity": "sha512-yJLLmLexii32mGrhW29qvU3QBVTu0GUmEf/J4XsBtVhp4JkIUFN/BjWqTF63yRvGApIDpZm5fa97LtYtINmfeQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -207,9 +208,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -268,9 +269,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
-      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+      "version": "9.26.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
+      "integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -288,13 +289,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.12.0",
+        "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -745,6 +746,85 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -886,6 +966,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -908,6 +1004,28 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz",
+      "integrity": "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.3",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -945,17 +1063,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1001,32 +1108,32 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
-      "integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
+      "version": "22.15.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.14.tgz",
+      "integrity": "sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.28.0.tgz",
-      "integrity": "sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.0.tgz",
+      "integrity": "sha512-/jU9ettcntkBFmWUzzGgsClEi2ZFiikMX5eEQsmxIAWMOn4H3D4rvHssstmAHGVvrYnaMqdWWWg0b5M6IN/MTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.28.0",
-        "@typescript-eslint/type-utils": "8.28.0",
-        "@typescript-eslint/utils": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0",
+        "@typescript-eslint/scope-manager": "8.32.0",
+        "@typescript-eslint/type-utils": "8.32.0",
+        "@typescript-eslint/utils": "8.32.0",
+        "@typescript-eslint/visitor-keys": "8.32.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1042,17 +1149,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.28.0.tgz",
-      "integrity": "sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.0.tgz",
+      "integrity": "sha512-B2MdzyWxCE2+SqiZHAjPphft+/2x2FlO9YBx7eKE1BCb+rqBlQdhtAEhzIEdozHd55DXPmxBdpMygFJjfjjA9A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.28.0",
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/typescript-estree": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0",
+        "@typescript-eslint/scope-manager": "8.32.0",
+        "@typescript-eslint/types": "8.32.0",
+        "@typescript-eslint/typescript-estree": "8.32.0",
+        "@typescript-eslint/visitor-keys": "8.32.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1068,14 +1175,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.28.0.tgz",
-      "integrity": "sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.0.tgz",
+      "integrity": "sha512-jc/4IxGNedXkmG4mx4nJTILb6TMjL66D41vyeaPWvDUmeYQzF3lKtN15WsAeTr65ce4mPxwopPSo1yUUAWw0hQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0"
+        "@typescript-eslint/types": "8.32.0",
+        "@typescript-eslint/visitor-keys": "8.32.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1086,16 +1193,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.28.0.tgz",
-      "integrity": "sha512-oRoXu2v0Rsy/VoOGhtWrOKDiIehvI+YNrDk5Oqj40Mwm0Yt01FC/Q7nFqg088d3yAsR1ZcZFVfPCTTFCe/KPwg==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.0.tgz",
+      "integrity": "sha512-t2vouuYQKEKSLtJaa5bB4jHeha2HJczQ6E5IXPDPgIty9EqcJxpr1QHQ86YyIPwDwxvUmLfP2YADQ5ZY4qddZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.28.0",
-        "@typescript-eslint/utils": "8.28.0",
+        "@typescript-eslint/typescript-estree": "8.32.0",
+        "@typescript-eslint/utils": "8.32.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1110,9 +1217,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.28.0.tgz",
-      "integrity": "sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.0.tgz",
+      "integrity": "sha512-O5Id6tGadAZEMThM6L9HmVf5hQUXNSxLVKeGJYWNhhVseps/0LddMkp7//VDkzwJ69lPL0UmZdcZwggj9akJaA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1124,20 +1231,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.28.0.tgz",
-      "integrity": "sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.0.tgz",
+      "integrity": "sha512-pU9VD7anSCOIoBFnhTGfOzlVFQIA1XXiQpH/CezqOBaDppRwTglJzCC6fUQGpfwey4T183NKhF1/mfatYmjRqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0",
+        "@typescript-eslint/types": "8.32.0",
+        "@typescript-eslint/visitor-keys": "8.32.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1151,16 +1258,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.28.0.tgz",
-      "integrity": "sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.0.tgz",
+      "integrity": "sha512-8S9hXau6nQ/sYVtC3D6ISIDoJzS1NsCK+gluVhLN2YkBPX+/1wkwyUiDKnxRh15579WoOIyVWnoyIf3yGI9REw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.28.0",
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/typescript-estree": "8.28.0"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.32.0",
+        "@typescript-eslint/types": "8.32.0",
+        "@typescript-eslint/typescript-estree": "8.32.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1175,13 +1282,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.28.0.tgz",
-      "integrity": "sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.0.tgz",
+      "integrity": "sha512-1rYQTCLFFzOI5Nl0c8LUpJT8HxpwVRn9E4CkMsYfuN6ctmQqExjSTzzSk0Tz2apmXy7WU6/6fyaZVVA/thPN+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
+        "@typescript-eslint/types": "8.32.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -1206,9 +1313,9 @@
       }
     },
     "node_modules/@yao-pkg/pkg-fetch": {
-      "version": "3.5.19",
-      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg-fetch/-/pkg-fetch-3.5.19.tgz",
-      "integrity": "sha512-EEURrS1Q5sSSAwaQ4zD0wZsquDiG8CroY3SCi7jYBoM0NG3eRA239mW6YMUYPNWUK4zCMhuK3bzFT5aIZP/rDg==",
+      "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg-fetch/-/pkg-fetch-3.5.21.tgz",
+      "integrity": "sha512-nlJ+rXersw70CQVSph7OfIN8lN6nCStjU7koXzh0WXiPvztZGqkoQTScHQCe1K8/tuKpeL0bEOYW0rP4QqMJ9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1224,11 +1331,32 @@
         "pkg-fetch": "lib-es5/bin.js"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "license": "ISC"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/acorn": {
       "version": "8.14.1",
@@ -1306,15 +1434,12 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1386,13 +1511,14 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/async-mutex": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1456,6 +1582,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -1501,6 +1648,66 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1549,6 +1756,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1559,69 +1782,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/color": {
@@ -1692,12 +1852,69 @@
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "license": "ISC"
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1769,16 +1986,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1792,6 +2037,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer2": {
@@ -1810,11 +2070,28 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -1826,6 +2103,39 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1835,6 +2145,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1850,23 +2167,24 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
-      "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
+      "version": "9.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz",
+      "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.2",
-        "@eslint/config-helpers": "^0.2.0",
-        "@eslint/core": "^0.12.0",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.13.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.23.0",
-        "@eslint/plugin-kit": "^0.2.7",
+        "@eslint/js": "9.26.0",
+        "@eslint/plugin-kit": "^0.2.8",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
+        "@modelcontextprotocol/sdk": "^1.8.0",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -1890,7 +2208,8 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
+        "optionator": "^0.9.3",
+        "zod": "^3.24.2"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -2054,6 +2373,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
+      "integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
+      "integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2062,6 +2414,65 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2151,6 +2562,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2166,6 +2595,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
       }
     },
     "node_modules/flat-cache": {
@@ -2203,6 +2642,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/from2": {
@@ -2305,53 +2776,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gauge/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/gauge/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/gauge/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2362,6 +2786,45 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -2370,23 +2833,21 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^4.0.1",
-        "minimatch": "^10.0.0",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "*"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2405,19 +2866,26 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -2431,6 +2899,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -2457,6 +2938,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -2476,6 +2983,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -2487,6 +3011,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -2588,6 +3125,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -2608,6 +3155,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extglob": {
@@ -2652,10 +3215,30 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2720,6 +3303,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -2740,6 +3343,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2748,6 +3361,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/levn": {
@@ -2827,6 +3450,39 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2849,6 +3505,29 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-response": {
@@ -2899,94 +3578,16 @@
       }
     },
     "node_modules/minizlib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/minizlib/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minizlib/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/minizlib/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/minizlib/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minizlib/node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mkdirp": {
@@ -3072,10 +3673,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-abi": {
-      "version": "3.74.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
-      "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3149,6 +3760,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3156,6 +3803,23 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -3174,6 +3838,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/p-is-promise": {
@@ -3243,6 +3917,63 @@
       "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==",
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -3300,6 +4031,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3320,18 +4061,28 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg": {
       "name": "@yao-pkg/pkg",
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-6.3.2.tgz",
-      "integrity": "sha512-gd4fh8dVC5qnKQD8HTwQrVLvT8TyQqwE59ky3LHtnke+6fBcTTrWavtbsVOwdL09IWqY+eSB+2AGCrSUnZ4wwg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-6.4.1.tgz",
+      "integrity": "sha512-pjePVt+DQP+HaJI5DfEZDX1pGsMMFjv1wuqfy/BwXlnffVIRk8lXjw7yVYvLQRcomf8Eaz2chDE5B6gR2SSaQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.23.0",
         "@babel/parser": "^7.23.0",
         "@babel/types": "^7.23.0",
-        "@yao-pkg/pkg-fetch": "3.5.19",
+        "@yao-pkg/pkg-fetch": "3.5.21",
         "into-stream": "^6.0.0",
         "minimist": "^1.2.6",
         "multistream": "^4.1.0",
@@ -3418,6 +4169,20 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -3437,6 +4202,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -3459,6 +4240,32 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -3501,6 +4308,20 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3571,62 +4392,34 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
       "bin": {
         "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
       },
       "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": ">= 18"
       }
     },
     "node_modules/run-parallel": {
@@ -3654,9 +4447,31 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -3671,10 +4486,74 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sharp": {
@@ -3737,17 +4616,87 @@
         "node": ">=8"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
       "engines": {
-        "node": ">=14"
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -3818,6 +4767,64 @@
         "string-split-by": "^1.0.0"
       }
     },
+    "node_modules/skia-canvas/node_modules/glob": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+      "integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/skia-canvas/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/stream-meter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
@@ -3837,6 +4844,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/string-split-by": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
@@ -3847,20 +4860,17 @@
       }
     },
     "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/string-width-cjs": {
@@ -3878,22 +4888,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -3903,21 +4898,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-ansi-cjs": {
@@ -3929,15 +4909,6 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4052,13 +5023,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.3",
+        "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
       },
       "engines": {
@@ -4069,9 +5040,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -4096,6 +5067,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4107,6 +5091,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/touchportal-api": {
@@ -4186,7 +5180,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -4214,10 +5209,25 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4229,9 +5239,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -4244,6 +5254,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unzipper": {
@@ -4282,6 +5302,16 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -4323,47 +5353,6 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wide-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4375,17 +5364,18 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -4407,59 +5397,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -4486,6 +5423,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {
@@ -4517,51 +5467,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -4583,6 +5488,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,164 +9,70 @@
       "version": "1.2.0-beta1",
       "license": "MIT",
       "dependencies": {
-        "async-mutex": "^0.4.0",
-        "sharp": "0.32.6",
-        "skia-canvas": "github:mpaperno/skia-canvas#master",
+        "async-mutex": "^0.5",
+        "sharp": "^0.33.5",
+        "skia-canvas": "2.0.2",
         "touchportal-api": "github:spdermn02/touchportal-node-api#master"
       },
       "bin": {
         "touchportal-dynamic-icons": "dist/index.js"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^4.30.0",
-        "adm-zip": "^0.5.9",
-        "eslint": "^7.32.0",
-        "fs-extra": "^10.1.0",
-        "pkg": "github:vercel/pkg#main",
-        "ts-node": "^10.9.1",
-        "typescript": "^5.0.4"
-      }
-    },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
+        "@typescript-eslint/eslint-plugin": "^8",
+        "adm-zip": "^0.5",
+        "eslint": "^9",
+        "fs-extra": "^11",
+        "pkg": "npm:@yao-pkg/pkg@^6.3",
+        "ts-node": "^10.9",
+        "typescript": "^5.8"
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
-      "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.2",
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "jsesc": "^2.5.1"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.18.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
-      "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.0"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -175,14 +81,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
-      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.18.10",
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -193,6 +99,7 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -205,103 +112,700 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+    "node_modules/@emnapi/runtime": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
+      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
+      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
+      "integrity": "sha512-yJLLmLexii32mGrhW29qvU3QBVTu0GUmEf/J4XsBtVhp4JkIUFN/BjWqTF63yRvGApIDpZm5fa97LtYtINmfeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
-        "debug": "^4.1.1",
-        "espree": "^7.3.0",
-        "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.0",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": "*"
       }
     },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true
+    "node_modules/@eslint/js": {
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
+      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.12.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -311,6 +815,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
       "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -326,11 +831,90 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -344,6 +928,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -353,6 +938,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -361,151 +947,176 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
-      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
-      "dev": true
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.0.tgz",
-      "integrity": "sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg==",
+      "version": "22.13.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
+      "integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
       "dev": true,
-      "peer": true
-    },
-    "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
-      "dev": true,
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^4.0.0",
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.28.0.tgz",
+      "integrity": "sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.28.0",
+        "@typescript-eslint/type-utils": "8.28.0",
+        "@typescript-eslint/utils": "8.28.0",
+        "@typescript-eslint/visitor-keys": "8.28.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "*"
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.28.0.tgz",
+      "integrity": "sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
+        "@typescript-eslint/scope-manager": "8.28.0",
+        "@typescript-eslint/types": "8.28.0",
+        "@typescript-eslint/typescript-estree": "8.28.0",
+        "@typescript-eslint/visitor-keys": "8.28.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.28.0.tgz",
+      "integrity": "sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
+        "@typescript-eslint/types": "8.28.0",
+        "@typescript-eslint/visitor-keys": "8.28.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.28.0.tgz",
+      "integrity": "sha512-oRoXu2v0Rsy/VoOGhtWrOKDiIehvI+YNrDk5Oqj40Mwm0Yt01FC/Q7nFqg088d3yAsR1ZcZFVfPCTTFCe/KPwg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.28.0",
+        "@typescript-eslint/utils": "8.28.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.0.1"
+      },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.28.0.tgz",
+      "integrity": "sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -513,59 +1124,118 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.28.0.tgz",
+      "integrity": "sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
+        "@typescript-eslint/types": "8.28.0",
+        "@typescript-eslint/visitor-keys": "8.28.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.28.0.tgz",
+      "integrity": "sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.28.0",
+        "@typescript-eslint/types": "8.28.0",
+        "@typescript-eslint/typescript-estree": "8.28.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.28.0.tgz",
+      "integrity": "sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@typescript-eslint/types": "8.28.0",
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@yao-pkg/pkg-fetch": {
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg-fetch/-/pkg-fetch-3.5.19.tgz",
+      "integrity": "sha512-EEURrS1Q5sSSAwaQ4zD0wZsquDiG8CroY3SCi7jYBoM0NG3eRA239mW6YMUYPNWUK4zCMhuK3bzFT5aIZP/rDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.6",
+        "picocolors": "^1.1.0",
+        "progress": "^2.0.3",
+        "semver": "^7.3.5",
+        "tar-fs": "^2.1.1",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "pkg-fetch": "lib-es5/bin.js"
       }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC"
     },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -578,32 +1248,39 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
       "dependencies": {
         "debug": "4"
       },
@@ -616,6 +1293,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -627,28 +1305,23 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -662,17 +1335,21 @@
     "node_modules/app-root-dir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
-      "integrity": "sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g=="
+      "integrity": "sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==",
+      "license": "MIT"
     },
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+      "license": "ISC"
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
       "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -681,120 +1358,54 @@
         "node": ">=10"
       }
     },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/async-mutex": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
-      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/b4a": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
-      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
           "type": "github",
@@ -809,6 +1420,84 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -819,14 +1508,16 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/cargo-cp-artifact": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.8.tgz",
-      "integrity": "sha512-3j4DaoTrsCD1MRkTF2Soacii0Nx7UHCce0EwUf4fHnggwiE4fbmF2AbnfzayR36DF8KGadfh7M/Yfy625kgPlA==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.9.tgz",
+      "integrity": "sha512-6F+UYzTaGB+awsTXg0uSJA1/b/B3DDJzpKVRu0UmyI7DmNeaAl2RFHuTGIN6fEgpadRxoXGb7gbC1xo4C3IdyA==",
+      "license": "MIT",
       "bin": {
         "cargo-cp-artifact": "bin/cargo-cp-artifact.js"
       }
@@ -836,6 +1527,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -848,11 +1540,13 @@
       }
     },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/cliui": {
@@ -860,16 +1554,81 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -882,6 +1641,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -892,12 +1652,14 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/color-string": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -907,6 +1669,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
       "bin": {
         "color-support": "bin.js"
       }
@@ -914,35 +1677,40 @@
     "node_modules/compare-versions": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -953,11 +1721,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -972,6 +1741,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -986,6 +1756,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
       }
@@ -994,17 +1766,20 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -1014,65 +1789,49 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "readable-stream": "^2.0.2"
       }
     },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
     },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1082,6 +1841,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1090,176 +1850,170 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
+      "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.3",
-        "@humanwhocodes/config-array": "^0.5.0",
-        "ajv": "^6.10.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-helpers": "^0.2.0",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.23.0",
+        "@eslint/plugin-kit": "^0.2.7",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.0.1",
-        "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.1",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.1.2",
-        "globals": "^13.6.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.0.0",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "progress": "^2.0.0",
-        "regexpp": "^3.1.0",
-        "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
-        "strip-json-comments": "^3.1.0",
-        "table": "^6.0.9",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
     "node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "engines": {
-        "node": ">=4"
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">= 4"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^7.4.0",
-        "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esquery": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -1267,20 +2021,12 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -1288,20 +2034,12 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/esrecurse/node_modules/estraverse": {
+    "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -1311,6 +2049,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1319,6 +2058,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
       }
@@ -1327,67 +2068,82 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1395,89 +2151,98 @@
         "node": ">=8"
       }
     },
-    "node_modules/flat-cache": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
-      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flatted": "^3.2.7",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-      "dev": true
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
     },
-    "node_modules/from2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/from2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/from2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -1489,6 +2254,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1496,27 +2262,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gauge": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
       "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
@@ -1532,11 +2305,59 @@
         "node": ">=10"
       }
     },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/gauge/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/gauge/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -1544,87 +2365,69 @@
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=12"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
-      "version": "13.22.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
-      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1634,25 +2437,22 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
+      "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1660,12 +2460,27 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -1678,6 +2493,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1691,22 +2507,25 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1723,6 +2542,7 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
@@ -1731,6 +2551,8 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1739,18 +2561,22 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/into-stream": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
       "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "from2": "^2.3.0",
         "p-is-promise": "^3.0.0"
@@ -1765,15 +2591,20 @@
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1784,6 +2615,7 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1792,6 +2624,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1801,6 +2634,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -1813,6 +2647,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1821,68 +2656,83 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "license": "ISC"
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+    "node_modules/jackspeak": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1891,10 +2741,11 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
-      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -1904,6 +2755,7 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -1912,33 +2764,43 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "license": "ISC",
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
       }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -1953,6 +2815,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1961,24 +2824,27 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -1989,6 +2855,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1997,75 +2864,159 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
+      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 18"
       }
     },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+    "node_modules/minizlib/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minizlib/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/minizlib/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minizlib/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minizlib/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/multistream": {
       "version": "4.1.0",
@@ -2086,26 +3037,47 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0",
         "readable-stream": "^3.6.0"
       }
     },
+    "node_modules/multistream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
-      "integrity": "sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==",
+      "version": "3.74.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
+      "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -2113,15 +3085,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2137,10 +3105,18 @@
         }
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
       "dependencies": {
         "abbrev": "1"
       },
@@ -2155,6 +3131,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
       "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
       "dependencies": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
@@ -2166,6 +3144,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2174,22 +3153,24 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -2200,15 +3181,55 @@
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
       "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -2219,17 +3240,30 @@
     "node_modules/parenthesis": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
-      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
+      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==",
+      "license": "MIT"
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2238,7 +3272,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2247,22 +3281,38 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
       "engines": {
-        "node": ">=8"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -2271,90 +3321,62 @@
       }
     },
     "node_modules/pkg": {
-      "version": "5.8.1",
-      "resolved": "git+ssh://git@github.com/vercel/pkg.git#bb042694e4289a1cbc530d2938babe35ccc84a93",
+      "name": "@yao-pkg/pkg",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-6.3.2.tgz",
+      "integrity": "sha512-gd4fh8dVC5qnKQD8HTwQrVLvT8TyQqwE59ky3LHtnke+6fBcTTrWavtbsVOwdL09IWqY+eSB+2AGCrSUnZ4wwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/generator": "7.18.2",
-        "@babel/parser": "7.18.4",
-        "@babel/types": "7.19.0",
-        "chalk": "^4.1.2",
-        "fs-extra": "^9.1.0",
-        "globby": "^11.1.0",
+        "@babel/generator": "^7.23.0",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "@yao-pkg/pkg-fetch": "3.5.19",
         "into-stream": "^6.0.0",
-        "is-core-module": "2.9.0",
         "minimist": "^1.2.6",
         "multistream": "^4.1.0",
-        "pkg-fetch": "3.5.2",
-        "prebuild-install": "7.1.1",
-        "resolve": "^1.22.0",
-        "stream-meter": "^1.0.4"
+        "picocolors": "^1.1.0",
+        "picomatch": "^4.0.2",
+        "prebuild-install": "^7.1.1",
+        "resolve": "^1.22.10",
+        "stream-meter": "^1.0.4",
+        "tar": "^7.4.3",
+        "tinyglobby": "^0.2.11",
+        "unzipper": "^0.12.3"
       },
       "bin": {
         "pkg": "lib-es5/bin.js"
-      }
-    },
-    "node_modules/pkg-fetch": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.5.2.tgz",
-      "integrity": "sha512-KlRF3cDS4J5PRTKh5dkF5s+CYKa+4eUXzymWqTKPU/p3WmYlWZu7AS0dH8moPxg+QcJNB4/wu1wVO2a0Asv2Dw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "fs-extra": "^9.1.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.6",
-        "progress": "^2.0.3",
-        "semver": "^7.3.5",
-        "tar-fs": "^2.1.1",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "pkg-fetch": "lib-es5/bin.js"
-      }
-    },
-    "node_modules/pkg-fetch/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/pkg/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+    "node_modules/pkg/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
+        "napi-build-utils": "^2.0.0",
         "node-abi": "^3.3.0",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
@@ -2374,6 +3396,7 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -2382,31 +3405,36 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2429,17 +3457,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
-    },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+      ],
+      "license": "MIT"
     },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -2454,33 +3480,26 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/require-directory": {
@@ -2488,6 +3507,7 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2496,6 +3516,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/require-from-app-root/-/require-from-app-root-0.2.1.tgz",
       "integrity": "sha512-TuNPLCO3uAA6Za80Vtz9F8YL0KpJiJ+ZQxOhdyV0N9j1VzweqXuHqVgacBdYo+25rWPA9jzqusijtKiTd2vW2g==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^10.0.0",
         "app-root-dir": "^1.0.2"
@@ -2504,29 +3525,25 @@
     "node_modules/require-from-app-root/node_modules/@types/node": {
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
-      "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2537,27 +3554,17 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/resolve/node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -2567,6 +3574,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -2577,10 +3586,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2594,6 +3615,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/run-parallel": {
@@ -2615,36 +3648,22 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2655,55 +3674,53 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.4",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^3.0.4",
-        "tunnel-agent": "^0.6.0"
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/tar-fs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
-      "dependencies": {
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      }
-    },
-    "node_modules/sharp/node_modules/tar-stream": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2715,15 +3732,22 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -2742,7 +3766,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -2762,6 +3787,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -2772,125 +3798,77 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/skia-canvas": {
-      "name": "@mpaperno/skia-canvas",
-      "version": "1.1.1-mp",
-      "resolved": "git+ssh://git@github.com/mpaperno/skia-canvas.git#94fb310fefac64ee880d471d1d4e9de822f00b9b",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/skia-canvas/-/skia-canvas-2.0.2.tgz",
+      "integrity": "sha512-LUa7P41NRNoCWhvPyX4aKP5SpeWDXmWYbonCt4FfkEdTuSssxpvYiK5Y69B0MudDR6LVNt9RBwpZfuCRpVSbbw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.9",
+        "@mapbox/node-pre-gyp": "^1.0.11",
         "cargo-cp-artifact": "^0.1",
-        "glob": "^8.0.3",
+        "glob": "^11.0.0",
         "path-browserify": "^1.0.1",
         "simple-get": "^4.0.1",
         "string-split-by": "^1.0.0"
       }
-    },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
     },
     "node_modules/stream-meter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
       "integrity": "sha512-4sOEtrbgFotXwnEuzzsQBYEV1elAeFSO8rSGeTwabuX1RRn/kEq9JVH7I0MRBhKVRR0sJkr0M0QCH7yOLf9fhQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.1.4"
       }
     },
-    "node_modules/stream-meter/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/stream-meter/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/stream-meter/node_modules/string_decoder": {
+    "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/streamx": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
-      "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
-      "dependencies": {
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-split-by": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
       "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
+      "license": "MIT",
       "dependencies": {
         "parenthesis": "^3.1.5"
       }
     },
     "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2900,13 +3878,66 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2916,6 +3947,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -2928,6 +3960,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2940,6 +3973,7 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2947,64 +3981,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/table": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/table/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/table/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -3015,12 +4015,16 @@
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -3032,19 +4036,64 @@
         "node": ">=6"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -3052,6 +4101,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -3060,8 +4110,8 @@
       }
     },
     "node_modules/touchportal-api": {
-      "version": "3.3.0",
-      "resolved": "git+ssh://git@github.com/spdermn02/touchportal-node-api.git#27de429389e00026a2bae495507587a4fc1f2645",
+      "version": "4.0.0",
+      "resolved": "git+ssh://git@github.com/spdermn02/touchportal-node-api.git#d82062eb8d7af4ac3e673384864e6ff1363d9901",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3072,13 +4122,28 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -3117,48 +4182,18 @@
         }
       }
     },
-    "node_modules/ts-node/node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/tsutils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -3171,6 +4206,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -3178,23 +4214,12 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3203,13 +4228,36 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "^11.2.0",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
       }
     },
     "node_modules/uri-js": {
@@ -3217,6 +4265,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -3224,29 +4273,27 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/v8-compile-cache": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
-      "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3256,7 +4303,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3271,15 +4318,85 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/wide-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wide-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -3292,30 +4409,91 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -3334,8 +4512,54 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yn": {
@@ -3343,8 +4567,22 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "touchportal-dynamic-icons",
-  "version": "1.2.0-beta1",
+  "version": "1.3.0",
   "config": {
-    "build": 4,
+    "build": 0,
     "nodeTarget": "node22"
   },
   "description": "Generate dynamic icons and images for Touch Portal buttons.",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lint:watch": "nodemon --watch .eslintrc.js --exec \"npm run lint\"",
     "start": "ts-node ./src/index.ts",
     "start-dist": "tsc && pkg . && node ./dist/index.js",
-    "gen-entry": "tsc && node builders/gen_entry.js"
+    "gen-entry": "tsc && node builders/gen_entry.js",
+    "postinstall": "patch-package"
   },
   "repository": {
     "type": "git",
@@ -62,6 +63,7 @@
     "adm-zip": "^0.5",
     "eslint": "^9",
     "fs-extra": "^11",
+    "patch-package": "^8.0.0",
     "pkg": "npm:@yao-pkg/pkg@^6.3",
     "ts-node": "^10.9",
     "typescript": "^5.8"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "homepage": "https://github.com/spdermn02/TouchPortal-Dynamic-Icons",
   "dependencies": {
-    "async-mutex": "^0.5",
     "sharp": "^0.33.5",
     "skia-canvas": "2.0.2",
     "touchportal-api": "github:spdermn02/touchportal-node-api#master"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "async-mutex": "^0.4.0",
     "sharp": "0.32.6",
-    "skia-canvas": "github:mpaperno/skia-canvas#master",
+    "skia-canvas": "2.0.2",
     "touchportal-api": "github:spdermn02/touchportal-node-api#master"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": 4,
     "nodeTarget": "node22"
   },
-  "description": "Generate Dynamic Icons for Touch Portal on Actions and 0-100% values",
+  "description": "Generate dynamic icons and images for Touch Portal buttons.",
   "main": "src/index.js",
   "bin": {
     "touchportal-dynamic-icons": "dist/index.js"
@@ -51,7 +51,7 @@
   "bugs": {
     "url": "https://github.com/spdermn02/TouchPortal-Dynamic-Icons/issues"
   },
-  "homepage": "https://github.com/spdermn02/TouchPortal-Dynamic-Icons#readme",
+  "homepage": "https://github.com/spdermn02/TouchPortal-Dynamic-Icons",
   "dependencies": {
     "async-mutex": "^0.5",
     "sharp": "^0.33.5",

--- a/package.json
+++ b/package.json
@@ -3,23 +3,28 @@
   "version": "1.2.0-beta1",
   "config": {
     "build": 4,
-    "nodeTarget": "node18"
+    "nodeTarget": "node22"
   },
   "description": "Generate Dynamic Icons for Touch Portal on Actions and 0-100% values",
   "main": "src/index.js",
   "bin": {
     "touchportal-dynamic-icons": "dist/index.js"
   },
+  "pkg": {
+    "assets": [
+      "node_modules/@img/sharp*/**/*"
+    ]
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "pkg": "pkg .",
-    "pkg-win": "pkg --targets node18-win-x64 .",
-    "pkg-mac": "pkg --targets node18-macos-x64 .",
-    "pkg-linux": "pkg --targets node18-linux-x64 .",
+    "pkg-win": "pkg --targets node22-win-x64 .",
+    "pkg-mac": "pkg --targets node22-macos-arm64 .",
+    "pkg-linux": "pkg --targets node22-linux-x64 .",
     "build": "tsc && node builders/build.js",
-    "build-win": "tsc && node builders/build.js -p Windows",
-    "build-mac": "tsc && node builders/build.js -p MacOS",
-    "build-linux": "tsc && node builders/build.js -p Linux",
+    "build-win": "tsc && node builders/build.js -p win32",
+    "build-mac": "tsc && node builders/build.js -p darwin",
+    "build-linux": "tsc && node builders/build.js -p linux",
     "tsc": "tsc",
     "jest": "jest",
     "ts-node-dev": "ts-node-dev",
@@ -48,18 +53,18 @@
   },
   "homepage": "https://github.com/spdermn02/TouchPortal-Dynamic-Icons#readme",
   "dependencies": {
-    "async-mutex": "^0.4.0",
-    "sharp": "0.32.6",
+    "async-mutex": "^0.5",
+    "sharp": "^0.33.5",
     "skia-canvas": "2.0.2",
     "touchportal-api": "github:spdermn02/touchportal-node-api#master"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.30.0",
-    "adm-zip": "^0.5.9",
-    "eslint": "^7.32.0",
-    "fs-extra": "^10.1.0",
-    "pkg": "github:vercel/pkg#main",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "@typescript-eslint/eslint-plugin": "^8",
+    "adm-zip": "^0.5",
+    "eslint": "^9",
+    "fs-extra": "^11",
+    "pkg": "npm:@yao-pkg/pkg@^6.3",
+    "ts-node": "^10.9",
+    "typescript": "^5.8"
   }
 }

--- a/patches/skia-canvas+2.0.2.patch
+++ b/patches/skia-canvas+2.0.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/skia-canvas/lib/classes/context.js b/node_modules/skia-canvas/lib/classes/context.js
-index 22bc9c8..8db0a1e 100644
+index 22bc9c8..6007a81 100644
 --- a/node_modules/skia-canvas/lib/classes/context.js
 +++ b/node_modules/skia-canvas/lib/classes/context.js
 @@ -67,8 +67,8 @@ class CanvasRenderingContext2D extends RustClass{
@@ -13,11 +13,297 @@ index 22bc9c8..8db0a1e 100644
      }
    }
  
+@@ -202,7 +202,7 @@ class CanvasRenderingContext2D extends RustClass{
+ 
+   // -- typography ------------------------------------------------------------
+   get font(){          return this.prop('font') }
+-  set font(str){              this.prop('font', css.font(str)) }
++  set font(str){              this.prop('font', css.font(str, {vw: this.canvas.width, vh: this.canvas.height})) }
+   get textAlign(){     return this.prop("textAlign") }
+   set textAlign(mode){        this.prop("textAlign", mode) }
+   get textBaseline(){  return this.prop("textBaseline") }
+@@ -212,9 +212,9 @@ class CanvasRenderingContext2D extends RustClass{
+   get fontStretch(){   return this.prop('fontStretch') }
+   set fontStretch(str){       this.prop('fontStretch', css.stretch(str)) }
+   get letterSpacing(){ return this.prop('letterSpacing') }
+-  set letterSpacing(str){     this.prop('letterSpacing', css.spacing(str)) }
++  set letterSpacing(str){     this.prop('letterSpacing', css.spacing(str, {vw: this.canvas.width, vh: this.canvas.height})) }
+   get wordSpacing(){   return this.prop('wordSpacing') }
+-  set wordSpacing(str){       this.prop('wordSpacing', css.spacing(str)) }
++  set wordSpacing(str){       this.prop('wordSpacing', css.spacing(str, {vw: this.canvas.width, vh: this.canvas.height})) }
+ 
+   measureText(text, maxWidth){
+     text = this.textWrap ? text : text + '\u200b' // include trailing whitespace by default
+@@ -262,7 +262,7 @@ class CanvasRenderingContext2D extends RustClass{
+   get shadowOffsetY(){ return this.prop("shadowOffsetY") }
+   set shadowOffsetY(y){       this.prop("shadowOffsetY", y) }
+   get filter(){        return this.prop('filter') }
+-  set filter(str){            this.prop('filter', css.filter(str)) }
++  set filter(str){            this.prop('filter', css.filter(str, {vw: this.canvas.width, vh: this.canvas.height})) }
+ 
+   [REPR](depth, options) {
+     let props = [ "canvas", "currentTransform", "fillStyle", "strokeStyle", "font", "fontStretch", "fontVariant",
 diff --git a/node_modules/skia-canvas/lib/classes/css.js b/node_modules/skia-canvas/lib/classes/css.js
-index 2af9927..19d74aa 100644
+index 2af9927..5662f04 100644
 --- a/node_modules/skia-canvas/lib/classes/css.js
 +++ b/node_modules/skia-canvas/lib/classes/css.js
-@@ -224,21 +224,32 @@ function parseFit(mode){
+@@ -4,133 +4,162 @@
+ 
+ "use strict"
+ 
++/**
++  @typedef {object} SizeReferenceOptions Defines options for calculating absolute sizes based on relative size units.
++  @prop {number} emSize Font "em" size reference for `em`, `rem`, `ex`, `ch` unit types.
++  @prop {number} vw Viewport (canvas) width reference for `vw`, `vmax`, `vmin` unit types.
++  @prop {number} vh Viewport (canvas) height reference for `vh`, `vmax`, `vmin` unit types.
++  @prop {boolean} pctAsVmin Calculate % unit type based on viewport size instead of em size (always `true` if `!emSize`).
++*/
++
+ // -- Font & Variant --------------------------------------------------------------------
+ //    https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant
+ //    https://www.w3.org/TR/css-fonts-3/#font-size-prop
+ 
+ var splitBy = require('string-split-by'),
+-    {DOMPoint} = require('./geometry'),
+     m, cache = {font:{}, variant:{}};
+ 
+ const styleRE = /^(normal|italic|oblique)$/,
+       smallcapsRE = /^(normal|small-caps)$/,
+       stretchRE = /^(normal|(semi-|extra-|ultra-)?(condensed|expanded))$/,
+       namedSizeRE = /(?:xx?-)?small|smaller|medium|larger|(?:xx?-)?large|normal/,
+-      numSizeRE = /^(\-?[\d\.]+)(px|pt|pc|in|cm|mm|%|em|ex|ch|rem|q)/,
++      numSizeRE = /^(\-?[\d\.]+)(px|pt|pc|in|cm|mm|%|ex|ch|r?em|q|vw|vh|vmin|vmax)/,
+       namedWeightRE = /^(normal|bold(er)?|lighter)$/,
+       numWeightRE = /^(1000|\d{1,3})$/,
+       parameterizedRE = /([\w\-]+)\((.*?)\)/,
++      defaultEmSize = 16,
+       unquote = s => s.replace(/^(['"])(.*?)\1$/, "$2"),
+       isSize = s => namedSizeRE.test(s) || numSizeRE.test(s),
+       isWeight = s => namedWeightRE.test(s) || numWeightRE.test(s);
+ 
+-function parseFont(str){
+-  if (cache.font[str]===undefined){
+-    try{
+-      if (typeof str !== 'string') throw new Error('Font specification must be a string')
+-      if (!str) throw new Error('Font specification cannot be an empty string')
+-
+-      let font = {style:'normal', variant:'normal', weight:'normal', stretch:'normal'},
+-          value = str.replace(/\s*\/\*s/, "/"),
+-          tokens = splitBy(value, /\s+/),
+-          token;
+-
+-      while (token = tokens.shift()) {
+-        let match = styleRE.test(token) ? 'style'
+-                  : smallcapsRE.test(token) ? 'variant'
+-                  : stretchRE.test(token) ? 'stretch'
+-                  : isWeight(token) ? 'weight'
+-                  : isSize(token) ? 'size'
+-                  : null;
+-
+-        switch (match){
+-          case "style":
+-          case "variant":
+-          case "stretch":
+-          case "weight":
+-            font[match] = token
+-            break;
+-
+-          case "size":
+-            // size is the pivot point between the style fields and the family name stack,
+-            // so start processing what's been collected
+-            let [emSize, leading] = splitBy(token, '/'),
+-                size = parseSize(emSize),
+-                lineHeight = leading ? parseSize(leading.replace(/(\d)$/, '$1em'), size) : undefined,
+-                weight = parseWeight(font.weight),
+-                family = splitBy(tokens.join(' '), /\s*,\s*/).map(unquote),
+-                features = font.variant=='small-caps' ? {on:['smcp', 'onum']} : {},
+-                {style, stretch, variant} = font;
+-
+-            // make sure all the numeric fields have legitimate values
+-            let invalid = !isFinite(size) ? `font size "${emSize}"`
+-                        : !isFinite(lineHeight) && lineHeight!==undefined ? `line height "${leading}"`
+-                        : !isFinite(weight) ? `font weight "${font.weight}"`
+-                        : family.length==0 ? `font family "${tokens.join(', ')}"`
+-                        : false;
+-
+-            if (!invalid){
+-              // include a re-stringified version of the decoded/absified values
+-              return cache.font[str] = Object.assign(font, {
+-                size, lineHeight, weight, family, features,
+-                canonical:[
+-                  style,
+-                  (variant !== style) && variant,
+-                  ([variant, style].indexOf(weight) == -1) && weight,
+-                  ([variant, style, weight].indexOf(stretch) == -1) && stretch,
+-                  `${size}px${isFinite(lineHeight) ? `/${lineHeight}px`: ''}`,
+-                  family.map(nm => nm.match(/\s/) ? `"${nm}"` : nm).join(", ")
+-                ].filter(Boolean).join(' ')
+-              })
+-            }
+-            throw new Error(`Invalid ${invalid}`)
+-
+-          default:
+-            throw new Error(`Unrecognized font attribute "${token}"`)
+-        }
++/**
++@param {string} str
++@param {SizeReferenceOptions} options
++*/
++function parseFont(str, options = {}){
++  const cacheKey = `${str}${options.vh||''}${options.vw||''}${options.emSize||''}`,
++    f = cache.font[cacheKey]
++  if (f !== undefined)
++    return f
++
++  try{
++    if (typeof str !== 'string') throw new Error('Font specification must be a string')
++    if (!str) throw new Error('Font specification cannot be an empty string')
++
++    let font = {style:'normal', variant:'normal', weight:'normal', stretch:'normal'},
++        value = str.replace(/\s*\/\*s/, "/"),
++        tokens = splitBy(value, /\s+/),
++        token;
++
++    while (token = tokens.shift()) {
++      let match = styleRE.test(token) ? 'style'
++                : smallcapsRE.test(token) ? 'variant'
++                : stretchRE.test(token) ? 'stretch'
++                : isWeight(token) ? 'weight'
++                : isSize(token) ? 'size'
++                : null;
++
++      switch (match){
++        case "style":
++        case "variant":
++        case "stretch":
++        case "weight":
++          font[match] = token
++          break;
++
++        case "size":
++          // size is the pivot point between the style fields and the family name stack,
++          // so start processing what's been collected
++          let [emSize, leading] = splitBy(token, '/'),
++              size = parseSize(emSize, { pctAsVmin: false, ...options }),
++              lineHeight = leading ? parseFloat(leading) * size : undefined,
++              weight = parseWeight(font.weight),
++              family = splitBy(tokens.join(' '), /\s*,\s*/).map(unquote),
++              features = font.variant=='small-caps' ? {on:['smcp', 'onum']} : {},
++              {style, stretch, variant} = font;
++
++          // make sure all the numeric fields have legitimate values
++          let invalid = !isFinite(size) ? `font size "${emSize}"`
++                      : !isFinite(lineHeight) && lineHeight!==undefined ? `line height "${leading}"`
++                      : !isFinite(weight) ? `font weight "${font.weight}"`
++                      : family.length==0 ? `font family "${tokens.join(', ')}"`
++                      : false;
++
++          if (!invalid){
++            // include a re-stringified version of the decoded/absified values
++            return cache.font[cacheKey] = Object.assign(font, {
++              size, lineHeight, weight, family, features,
++              canonical:[
++                style,
++                (variant !== style) && variant,
++                ([variant, style].indexOf(weight) == -1) && weight,
++                ([variant, style, weight].indexOf(stretch) == -1) && stretch,
++                `${size}px${isFinite(lineHeight) ? `/${lineHeight}px`: ''}`,
++                family.map(nm => nm.match(/\s/) ? `"${nm}"` : nm).join(", ")
++              ].filter(Boolean).join(' ')
++            })
++          }
++          throw new Error(`Invalid ${invalid}`)
++
++        default:
++          throw new Error(`Unrecognized font attribute "${token}"`)
+       }
+-      throw new Error('Could not find a font size value')
+-    } catch(e) {
+-      // console.warn(Object.assign(e, {name:"Warning"}))
+-      cache.font[str] = null
+     }
++    throw new Error('Could not find a font size value')
++  } catch(e) {
++    // console.warn(Object.assign(e, {name:"Warning"}))
++    return cache.font[cacheKey] = null
+   }
+-  return cache.font[str]
+ }
+ 
+-function parseSize(str, emSize=16){
++function sizeUnitFactor(unit, {emSize = defaultEmSize, vw = 300, vh = 150, pctAsVmin = true} = {}){
++  switch (unit) {
++    case 'px':   return 1
++    case 'pt':   return 1 / 0.75
++    case '%':    return (pctAsVmin || !emSize ? Math.min(vw, vh) : emSize) / 100
++    case 'pc':   return 16
++    case 'in':   return 96
++    case 'cm':   return 96 / 2.54
++    case 'mm':   return 96 / 25.4
++    case 'q':    return 96 / 25.4 / 4
++    case 'vw':   return vw / 100
++    case 'vh':   return vh / 100
++    case 'vmin': return Math.min(vw, vh) / 100
++    case 'vmax': return Math.max(vw, vh) / 100
++    case 'em':
++    case 'rem':  return emSize
++    case 'ch':
++    case 'ex':   return emSize / 2
++    default:     return NaN
++  }
++}
++
++/**
++@param {string} str
++@param {SizeReferenceOptions} options
++*/
++function parseSize(str, options = {}){
+   if (m = numSizeRE.exec(str)){
+     let [size, unit] = [parseFloat(m[1]), m[2]]
+-    return size * (unit == 'px' ? 1
+-                :  unit == 'pt' ? 1 / 0.75
+-                :  unit == '%' ? emSize / 100
+-                :  unit == 'pc' ? 16
+-                :  unit == 'in' ? 96
+-                :  unit == 'cm' ? 96.0 / 2.54
+-                :  unit == 'mm' ? 96.0 / 25.4
+-                :  unit == 'q' ? 96 / 25.4 / 4
+-                :  unit.match('r?em') ? emSize
+-                :  NaN )
++    return size * sizeUnitFactor(unit, options)
+   }
+ 
+   if (m = namedSizeRE.exec(str)){
+-    return emSize * (sizeMap[m[0]] || 1.0)
++    options = {emSize: defaultEmSize, ...options}
++    return options.emSize * (sizeMap[m[0]] || 1.0)
+   }
+ 
+   return NaN
+ }
+ 
+-function parseFlexibleSize(str){
++/**
++@param {string} str
++@param {SizeReferenceOptions} options
++*/
++function parseFlexibleSize(str, options = {}){
+   if (m = numSizeRE.exec(str)){
+-    let [size, unit] = [parseFloat(m[1]), m[2]],
+-        px = size * (unit == 'px' ? 1
+-          :  unit == 'pt' ? 1 / 0.75
+-          :  unit == 'pc' ? 16
+-          :  unit == 'in' ? 96
+-          :  unit == 'cm' ? 96.0 / 2.54
+-          :  unit == 'mm' ? 96.0 / 25.4
+-          :  unit == 'q' ? 96 / 25.4 / 4
+-          :  NaN )
++    const [size, unit] = [parseFloat(m[1]), m[2]],
++        px = size * sizeUnitFactor(unit, options)
+     return {size, unit, px}
+   }
+   return null
+@@ -224,21 +253,32 @@ function parseFit(mode){
  //    https://github.com/fserb/canvas2D/blob/master/spec/roundrect.md
  
  function parseCornerRadii(r){
@@ -33,7 +319,7 @@ index 2af9927..19d74aa 100644
 +    return [[0,0],[0,0],[0,0],[0,0]];
 +
 +  r = [r].flat().slice(0, 4)
-+  for (let [i, v] of Object.entries(r)) {
++  for (const [i, v] of Object.entries(r)) {
 +    if (typeof v == 'number') {
 +      if (!Number.isFinite(v))
 +        return null // silently abort
@@ -43,7 +329,7 @@ index 2af9927..19d74aa 100644
 +      continue;
 +    }
 +    // assume value is an object with {x,y} properties, the isFinite() checks will return false if it isn't
-+    if (!Number.isFinite(v?.x) || !Number.isFinite(v?.y))
++    if (!Number.isFinite(v.x) || !Number.isFinite(v.y))
 +      return null // silently abort
 +    if (v.x < 0 || v.y < 0)
 +      throw new Error("Corner radius cannot be negative")
@@ -60,6 +346,36 @@ index 2af9927..19d74aa 100644
  }
  
  // -- Image Filters -----------------------------------------------------------------------
+@@ -249,7 +289,11 @@ var plainFilterRE = /(blur|hue-rotate|brightness|contrast|grayscale|invert|opaci
+     percentValueRE = /^(\+|-)?\d+%$/,
+     angleValueRE = /([\d\.]+)(deg|g?rad|turn)/;
+ 
+-function parseFilter(str){
++/**
++@param {string} str
++@param {SizeReferenceOptions} options
++*/
++function parseFilter(str, options = {}){
+   let filters = {}
+   let canonical = []
+ 
+@@ -259,14 +303,14 @@ function parseFilter(str){
+           args = m[1].trim().split(/\s+/),
+           lengths = args.slice(0,3),
+           color = args.slice(3).join(' '),
+-          dims = lengths.map(s => parseSize(s)).filter(isFinite);
++          dims = lengths.map(s => parseSize(s, options)).filter(isFinite);
+       if (dims.length==3 && !!color){
+         filters[kind] = [...dims, color]
+         canonical.push(`${kind}(${lengths.join(' ')} ${color.replace(/ /g,'')})`)
+       }
+     }else if (m = plainFilterRE.exec(spec)){
+       let [kind, arg] = m.slice(1)
+-      let val = kind=='blur' ? parseSize(arg)
++      let val = kind=='blur' ? parseSize(arg, options)
+               : kind=='hue-rotate' ? parseAngle(arg)
+               : parsePercentage(arg);
+       if (isFinite(val)){
 diff --git a/node_modules/skia-canvas/lib/classes/path.js b/node_modules/skia-canvas/lib/classes/path.js
 index 043ed0f..212387b 100644
 --- a/node_modules/skia-canvas/lib/classes/path.js

--- a/patches/skia-canvas+2.0.2.patch
+++ b/patches/skia-canvas+2.0.2.patch
@@ -1,0 +1,90 @@
+diff --git a/node_modules/skia-canvas/lib/classes/context.js b/node_modules/skia-canvas/lib/classes/context.js
+index 22bc9c8..8db0a1e 100644
+--- a/node_modules/skia-canvas/lib/classes/context.js
++++ b/node_modules/skia-canvas/lib/classes/context.js
+@@ -67,8 +67,8 @@ class CanvasRenderingContext2D extends RustClass{
+     let radii = css.radii(r)
+     if (radii){
+       if (w < 0) radii = [radii[1], radii[0], radii[3], radii[2]]
+-      if (h < 0) radii = [radii[3], radii[2], radii[1], radii[0]]
+-      this.ƒ("roundRect", x, y, w, h, ...radii.map(({x, y}) => [x, y]).flat())
++      if (h < 0) radii.reverse()
++      this.ƒ("roundRect", x, y, w, h, ...radii.flat())
+     }
+   }
+ 
+diff --git a/node_modules/skia-canvas/lib/classes/css.js b/node_modules/skia-canvas/lib/classes/css.js
+index 2af9927..19d74aa 100644
+--- a/node_modules/skia-canvas/lib/classes/css.js
++++ b/node_modules/skia-canvas/lib/classes/css.js
+@@ -224,21 +224,32 @@ function parseFit(mode){
+ //    https://github.com/fserb/canvas2D/blob/master/spec/roundrect.md
+ 
+ function parseCornerRadii(r){
+-  r = [r].flat()
+-         .map(n => n instanceof DOMPoint ? n : new DOMPoint(n, n))
+-         .slice(0, 4)
+-
+-  if (r.some(pt => !Number.isFinite(pt.x) || !Number.isFinite(pt.y))){
+-    return null // silently abort
+-  }else if (r.some(pt => pt.x < 0 || pt.y < 0)){
+-    throw new Error("Corner radius cannot be negative")
++  if (r == undefined)
++    return [[0,0],[0,0],[0,0],[0,0]];
++
++  r = [r].flat().slice(0, 4)
++  for (let [i, v] of Object.entries(r)) {
++    if (typeof v == 'number') {
++      if (!Number.isFinite(v))
++        return null // silently abort
++      if (v < 0)
++        throw new Error("Corner radius cannot be negative")
++      r[i] = [v, v]
++      continue;
++    }
++    // assume value is an object with {x,y} properties, the isFinite() checks will return false if it isn't
++    if (!Number.isFinite(v?.x) || !Number.isFinite(v?.y))
++      return null // silently abort
++    if (v.x < 0 || v.y < 0)
++      throw new Error("Corner radius cannot be negative")
++    r[i] = [v.x, v.y]
+   }
+ 
+   return r.length == 1 ? [r[0], r[0], r[0], r[0]]
+        : r.length == 2 ? [r[0], r[1], r[0], r[1]]
+        : r.length == 3 ? [r[0], r[1], r[2], r[1]]
+-       : r.length == 4 ? [r[0], r[1], r[2], r[3]]
+-       : [0, 0, 0, 0].map(n => new DOMPoint(n, n))
++       : r.length == 4 ? r
++       : [[0,0],[0,0],[0,0],[0,0]]
+ }
+ 
+ // -- Image Filters -----------------------------------------------------------------------
+diff --git a/node_modules/skia-canvas/lib/classes/path.js b/node_modules/skia-canvas/lib/classes/path.js
+index 043ed0f..212387b 100644
+--- a/node_modules/skia-canvas/lib/classes/path.js
++++ b/node_modules/skia-canvas/lib/classes/path.js
+@@ -65,8 +65,8 @@ class Path2D extends RustClass{
+     let radii = css.radii(r)
+     if (radii){
+       if (w < 0) radii = [radii[1], radii[0], radii[3], radii[2]]
+-      if (h < 0) radii = [radii[3], radii[2], radii[1], radii[0]]
+-      this.ƒ("roundRect", x, y, w, h, ...radii.map(({x, y}) => [x, y]).flat())
++      if (h < 0) radii.reverse()
++      this.ƒ("roundRect", x, y, w, h, ...radii.flat())
+     }
+   }
+ 
+diff --git a/node_modules/skia-canvas/lib/index.d.ts b/node_modules/skia-canvas/lib/index.d.ts
+index 01f977a..33a8558 100644
+--- a/node_modules/skia-canvas/lib/index.d.ts
++++ b/node_modules/skia-canvas/lib/index.d.ts
+@@ -249,7 +249,7 @@ declare var DOMMatrix: {
+ // Canvas
+ //
+ 
+-export type ExportFormat = "png" | "jpg" | "jpeg" | "webp" | "pdf" | "svg";
++export type ExportFormat = "png" | "jpg" | "jpeg" | "webp" | "pdf" | "svg" | "raw";
+ 
+ export interface RenderOptions {
+   /** Page to export: Defaults to 1 (i.e., first page) */

--- a/patches/skia-canvas+2.0.2.patch
+++ b/patches/skia-canvas+2.0.2.patch
@@ -392,10 +392,52 @@ index 043ed0f..212387b 100644
    }
  
 diff --git a/node_modules/skia-canvas/lib/index.d.ts b/node_modules/skia-canvas/lib/index.d.ts
-index 01f977a..33a8558 100644
+index 01f977a..0fd5a1b 100644
 --- a/node_modules/skia-canvas/lib/index.d.ts
 +++ b/node_modules/skia-canvas/lib/index.d.ts
-@@ -249,7 +249,7 @@ declare var DOMMatrix: {
+@@ -59,6 +59,13 @@ interface DOMRect extends DOMRectReadOnly {
+   y: number;
+ }
+ 
++interface DOMRectInit {
++  height?: number;
++  width?: number;
++  x?: number;
++  y?: number;
++}
++
+ declare var DOMRect: {
+   prototype: DOMRect;
+   new(x?: number, y?: number, width?: number, height?: number): DOMRect;
+@@ -110,8 +117,11 @@ declare var DOMRectReadOnly: {
+ // Images
+ //
+ 
++/** [Skia Canvas Docs](http://skia-canvas.org/api/image#loadimage) */
+ export function loadImage(src: string | Buffer): Promise<Image>
++/** [Skia Canvas Docs](http://skia-canvas.org/api/imagedata#loadimagedata) */
+ export function loadImageData(src: string | Buffer, width: number, height?:number): Promise<ImageData>
++/** [Skia Canvas Docs](http://skia-canvas.org/api/imagedata#loadimagedata) */
+ export function loadImageData(src: string | Buffer, width: number, height:number, settings?:ImageDataSettings): Promise<ImageData>
+ 
+ export type ColorSpace = "srgb" // add "display-p3" when skia_safe supports it
+@@ -127,6 +137,7 @@ interface ImageDataSettings {
+   colorType?: ColorType
+ }
+ 
++/** [Skia Canvas Docs](https://skia-canvas.org/api/imagedata) */
+ export class ImageData {
+   prototype: ImageData
+   constructor(sw: number, sh: number, settings?: ImageDataSettings)
+@@ -141,6 +152,7 @@ export class ImageData {
+   readonly width: number
+ }
+ 
++/** [Skia Canvas Docs](https://skia-canvas.org/api/image) */
+ export class Image extends EventEmitter {
+   constructor()
+   get src(): string
+@@ -249,7 +261,7 @@ declare var DOMMatrix: {
  // Canvas
  //
  

--- a/src/common.ts
+++ b/src/common.ts
@@ -11,5 +11,6 @@ export const PluginSettings = {
     defaultIconSize: <SizeType> { width: 128, height: 128 },
     defaultGpuRendering: <boolean> false,
     defaultOutputCompressionLevel: <number> 4,  // MP: 4 seems to give the highest effective compression in my tests, no gains with higher levels but does slow down.
+    defaultOutputQuality: <number> 100,
     imageFilesBasePath: <string> ''
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import TP from 'touchportal-api'
 import * as C from './utils/consts'
 import { ColorUpdateType } from './modules/enums';
-import type { ConstructorType, TpActionDataArrayType } from './modules/types'
+import type { TpActionDataArrayType } from './modules/types'
 import type { IColorElement, ILayerElement, IValuedElement } from './modules/interfaces';
 import { Point, type PointType, Size } from './modules/geometry';
 import { DynamicIcon, ParseState, globalImageCache } from "./modules";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { DynamicIcon, ParseState, globalImageCache } from "./modules";
 import * as LE from "./modules/elements";
 import { ConsoleEndpoint, Logger, logging , LogLevel } from './modules/logging';
 import { setTPClient, PluginSettings } from './common'
-import { parseIntOrDefault, parseBoolOrDefault, clamp } from './utils/helpers'
+import { parseIntOrDefault, /* parseBoolOrDefault, */ clamp } from './utils/helpers'
 import { dirname as pdirname, extname as pathExtName, isAbsolute as pathIsAbs, join as pathJoin, resolve as presolve } from 'path';
 import { concurrency as sharp_concurrency } from 'sharp';
 const { version: pluginVersion } = require('../package.json');  // 'import' causes lint error in VSCode
@@ -398,9 +398,10 @@ function handleIconAction(actionId: string, data: TpActionDataArrayType)
             if (parseState.dr.quality != undefined)
                 icon.outputCompressionOptions.quality = clamp(parseIntOrDefault(parseState.dr.quality, PluginSettings.defaultOutputQuality), 1, 100)
 
-            // GPU rendering setting choices: "default", "Enabled", "Disabled"; Added in v1.2.0-a1, removed after 1.2.0-a3, re-added in 1.3.0.
-            if (parseState.dr.gpu != undefined)
-                icon.gpuRendering = parseBoolOrDefault(parseState.dr.gpu, PluginSettings.defaultGpuRendering)
+            // GPU rendering setting choices: "default", "Enabled", "Disabled"; Added in v1.2.0-a1, removed after 1.2.0-a3
+            // Disabled for now, revisit later if GPU usage becomes stable.
+            // if (parseState.dr.gpu != undefined)
+                // icon.gpuRendering = parseBoolOrDefault(parseState.dr.gpu, PluginSettings.defaultGpuRendering)
 
             if (action & 1)
                 icon.finalize()
@@ -610,9 +611,10 @@ function onSettings(settings:{ [key:string]:string }[]) {
             case C.SettingName.MaxImageGenThreads:
                 canvas_concurrency(clamp(parseIntOrDefault(val, DEFAULT_CONCURRENCY), 1, SYS_MAX_THREADS));
                 break;
-            case C.SettingName.GPU:
-                PluginSettings.defaultGpuRendering = parseBoolOrDefault(val, PluginSettings.defaultGpuRendering);
-                break;
+            // Disabled for now, revisit later if GPU usage becomes stable.
+            // case C.SettingName.GPU:
+            //     PluginSettings.defaultGpuRendering = parseBoolOrDefault(val, PluginSettings.defaultGpuRendering);
+            //     break;
         }
     });
     // logger.debug("settings: %O", settings)

--- a/src/index.ts
+++ b/src/index.ts
@@ -378,9 +378,9 @@ function handleIconAction(actionId: string, data: TpActionDataArrayType)
             if (parseState.dr.action && parseState.dr.action.length < 17)
                 action = parseState.dr.action[0] == 'F' ? 1 : 2
 
-            // Output compression choices: "default", "none", "1"..."9"; Added in v1.2.0-a3
+            // Output compression choices: "default", "None", "1"..."9"; Added in v1.2.0-a3
             if (parseState.dr.cl != undefined)
-                icon.outputCompressionOptions.compressionLevel = parseIntOrDefault(parseState.dr.cl, PluginSettings.defaultOutputCompressionLevel)
+                icon.outputCompressionOptions.compressionLevel = parseState.dr.cl[0] == 'N' ? 0 : parseIntOrDefault(parseState.dr.cl, PluginSettings.defaultOutputCompressionLevel)
 
             // Output quality level: "default", 1-100; Added in v1.3.0
             if (parseState.dr.quality != undefined)

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,8 @@ const ACTION_TO_ELEMENT_MAP: LayerElementRecord = {
     [C.Act.IconPath      ]: { type: LE.FreeformPath },
     [C.Act.IconText      ]: { type: LE.StyledText },
     [C.Act.IconImage     ]: { type: LE.DynamicImage },
+    [C.Act.IconCircularTicks]: { type: LE.CircularTicks },
+    [C.Act.IconLinearTicks]:   { type: LE.LinearTicks },
     // Elements which affect other layers in some way.
     [C.Act.IconStyle     ]: { type: LE.DrawingStyle,    prev_layer: true },
     [C.Act.IconClip      ]: { type: LE.ClippingMask,    prev_layer: true },

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,6 +382,10 @@ function handleIconAction(actionId: string, data: TpActionDataArrayType)
             if (parseState.dr.cl != undefined)
                 icon.outputCompressionOptions.compressionLevel = parseIntOrDefault(parseState.dr.cl, PluginSettings.defaultOutputCompressionLevel)
 
+            // Output quality level: "default", 1-100; Added in v1.3.0
+            if (parseState.dr.quality != undefined)
+                icon.outputCompressionOptions.quality = clamp(parseIntOrDefault(parseState.dr.quality, PluginSettings.defaultOutputQuality), 1, 100)
+
             // GPU rendering setting choices: "default", "Enabled", "Disabled"; Added in v1.2.0-a1, removed after 1.2.0-a3, re-added in 1.3.0.
             if (parseState.dr.gpu != undefined)
                 icon.gpuRendering = parseBoolOrDefault(parseState.dr.gpu, PluginSettings.defaultGpuRendering)
@@ -540,6 +544,9 @@ function onSettings(settings:{ [key:string]:string }[]) {
                 break;
             case C.SettingName.PngCompressLevel:
                 PluginSettings.defaultOutputCompressionLevel = clamp(parseIntOrDefault(val, PluginSettings.defaultOutputCompressionLevel), 0, 9);
+                break;
+            case C.SettingName.PngQualityLevel:
+                PluginSettings.defaultOutputQuality = clamp(parseIntOrDefault(val, PluginSettings.defaultOutputQuality), 1, 100);
                 break;
             case C.SettingName.MaxImageProcThreads:
                 sharp_concurrency(clamp(parseIntOrDefault(val, DEFAULT_CONCURRENCY), 1, SYS_MAX_THREADS));

--- a/src/index.ts
+++ b/src/index.ts
@@ -497,13 +497,12 @@ function handleIconUpdateAction(actionId: string, icon: DynamicIcon, parseState:
         // `break` from cases to finish the update process or `return` to cancel.
         case C.Act.IconSetTx:
             // Updates/sets a transformation on an existing icon layer of a type which supports it.
-            parseState.setPos(2)  // set up position for Tx parsing; TODO: convert Tx parser to use named fields instead of positional
             // If layer is a Tx, update it.
             if (el instanceof LE.Transformation)
-                el.loadFromActionData(parseState)
+                el.loadFromDataRecord(dr)
             // Image element types have their own transform property which we can update directly.
             else if (el instanceof LE.DynamicImage)
-                el.loadTransform(parseState)
+                el.loadTransform(dr)
             // If this is a single-layer icon then we actually want to append this Tx (should only happen once per icon).
             // If we already appended a Tx to a single-layer icon (upon last update), then the next layer would already be a Tx.
             else if (!icon.delayGeneration && !layerIdx)

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ const ACTION_TO_ELEMENT_MAP: LayerElementRecord = {
     [C.Act.IconPath      ]: { type: LE.FreeformPath },
     [C.Act.IconText      ]: { type: LE.StyledText },
     [C.Act.IconImage     ]: { type: LE.DynamicImage },
+    [C.Act.IconScript    ]: { type: LE.Script },
     [C.Act.IconCircularTicks]: { type: LE.CircularTicks },
     [C.Act.IconLinearTicks]:   { type: LE.LinearTicks },
     // Elements which affect other layers in some way.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import * as LE from "./modules/elements";
 import { ConsoleEndpoint, Logger, logging , LogLevel } from './modules/logging';
 import { setTPClient, PluginSettings } from './common'
 import { qualifyFilepath, parseIntOrDefault, /* parseBoolOrDefault, */ clamp } from './utils/helpers'
+import './utils/extensions'
 import { dirname as pdirname, extname as pathExtName, resolve as presolve } from 'path';
 import { concurrency as sharp_concurrency } from 'sharp';
 const { version: pluginVersion } = require('../package.json');  // 'import' causes lint error in VSCode

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import { DynamicIcon, ParseState, globalImageCache } from "./modules";
 import * as LE from "./modules/elements";
 import { ConsoleEndpoint, Logger, logging , LogLevel } from './modules/logging';
 import { setTPClient, PluginSettings } from './common'
-import { parseIntOrDefault, /* parseBoolOrDefault, */ clamp } from './utils/helpers'
-import { dirname as pdirname, extname as pathExtName, isAbsolute as pathIsAbs, join as pathJoin, resolve as presolve } from 'path';
+import { qualifyFilepath, parseIntOrDefault, /* parseBoolOrDefault, */ clamp } from './utils/helpers'
+import { dirname as pdirname, extname as pathExtName, resolve as presolve } from 'path';
 import { concurrency as sharp_concurrency } from 'sharp';
 const { version: pluginVersion } = require('../package.json');  // 'import' causes lint error in VSCode
 
@@ -424,15 +424,13 @@ function handleIconAction(actionId: string, data: TpActionDataArrayType)
                 logger.warn(`Unsupported output file format "${pathExtName(parseState.dr.file)}" for icon '${icon.name}'. Supported formats: ${[...OUTPUT_FORMATS.keys()].join(',')}`)
                 return
             }
+
             // rendering options for icon.render()
             const options = {
-                file: parseState.dr.file,
+                file: qualifyFilepath(parseState.dr.file),
                 format,
                 output: {}
             }
-            // expand relative paths if we have a default path
-            if (!!PluginSettings.imageFilesBasePath && !pathIsAbs(options.file))
-                options.file = pathJoin(PluginSettings.imageFilesBasePath, options.file)
 
             // Convert name=value pairs to Sharp output options object.
             // We don't validate the values here... would be too much. Sharp will handle it and we'll log any errors at that point.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import TP from 'touchportal-api'
 import * as C from './utils/consts'
 import { ColorUpdateType } from './modules/enums';
-import type { TpActionDataArrayType } from './modules/types'
 import type { IColorElement, ILayerElement, IValuedElement } from './modules/interfaces';
 import { Point, type PointType, Size } from './modules/geometry';
 import { DynamicIcon, ParseState, globalImageCache } from "./modules";

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,6 +230,8 @@ function removeIcons(iconNames: string[], removeStates = true) {
             if (removeStates)
                 createOrRemoveIconStates(icon, Point.new());
             globalImageCache().clearIconName(icon.name);
+            if (!g_quitting)
+                logger.info("Deleted icon instance '%s'", icon.name);
             g_dyanmicIconStates.delete(n);
         }
     });

--- a/src/modules/DynamicIcon.ts
+++ b/src/modules/DynamicIcon.ts
@@ -122,8 +122,7 @@ export default class DynamicIcon
     }
 
     // Sends the canvas contents after re-compressing it with Sharp.
-    private sendCompressedImage(canvas: Canvas) {
-        const size = this.actualSize();
+    private sendCompressedImage(canvas: Canvas, size: SizeType) {
         const raw: CreateRaw = { width: size.width, height: size.height, channels: 4, premultiplied: true };
         canvas
         .toBuffer("raw" as any)
@@ -139,8 +138,8 @@ export default class DynamicIcon
 
     // Sends the canvas tiled, w/out compression.
     // While this isn't really any faster than using Skia anyway, it does use less CPU and/or uses GPU instead when that option is enabled.
-    private sendCanvasTiles(canvas: Canvas) {
-        const size = this.actualSize(),
+    private sendCanvasTiles(canvas: Canvas, size: SizeType) {
+        const
             tileW = Math.ceil(size.width / this.tile.x),
             tileH = Math.ceil(size.height / this.tile.y);
         for (let y=0; y < this.tile.y; ++y) {
@@ -165,8 +164,8 @@ export default class DynamicIcon
 
     // Send the canvas contents by breaking up into tiles using Sharp, with added compression.
     // Much more efficient than using the method in sendCanvasTiles() and then compressing each resulting canvas tile.
-    private sendCompressedTiles(canvas: Canvas) {
-        const size = this.actualSize(),
+    private sendCompressedTiles(canvas: Canvas, size: SizeType) {
+        const
             tileW = Math.ceil(size.width / this.tile.x),
             tileH = Math.ceil(size.height / this.tile.y);
         const raw: CreateRaw = { width: size.width, height: size.height, channels: 4, premultiplied: true };
@@ -323,16 +322,16 @@ export default class DynamicIcon
 
             if (this.isTiled) {
                 if (this.outputCompressionOptions.compressionLevel > 0)
-                    this.sendCompressedTiles(canvas);
+                    this.sendCompressedTiles(canvas, rect.size);
                 else
-                    this.sendCanvasTiles(canvas);
+                    this.sendCanvasTiles(canvas, rect.size);
                 return;
             }
 
             // Not tiled, send whole rendered canvas at once.
 
             if (this.outputCompressionOptions.compressionLevel > 0)
-                this.sendCompressedImage(canvas);
+                this.sendCompressedImage(canvas, rect.size);
             else
                 this.sendCanvasImage(this.name, canvas);
 

--- a/src/modules/DynamicIcon.ts
+++ b/src/modules/DynamicIcon.ts
@@ -115,7 +115,7 @@ export default class DynamicIcon
                 try {
                     // Extract tile-sized part of the current canvas onto a new canvas which is the size of a tile.
                     const tileCtx = new Canvas(tw, th).getContext("2d");
-                    // tileCtx.canvas.gpu = this.gpuRendering;
+                    tileCtx.canvas.gpu = this.gpuRendering;
                     tileCtx.drawCanvas(canvas, tl, tt, tw, th, 0, 0, tw, th);
                     this.sendCanvasImage(this.getTileStateId({x: x, y: y}), tileCtx.canvas);
                 }

--- a/src/modules/DynamicIcon.ts
+++ b/src/modules/DynamicIcon.ts
@@ -141,7 +141,7 @@ export default class DynamicIcon
         canvas
         .toBuffer("raw" as any)
         .then((data: Buffer) => {
-            sharp(data, { raw : { width: size.width, height: size.height, channels: 4, premultiplied: true } })
+            sharp(data, { raw : { width: size.width, height: size.height, channels: 4, premultiplied: false } })
             .png(this.outputCompressionOptions)
             .toBuffer()
             .then((b: Buffer) => this.sendStateData(this.name, b) )
@@ -170,7 +170,7 @@ export default class DynamicIcon
     // Send the canvas contents by breaking up into tiles using Sharp, with added compression.
     // Much more efficient than using the method in sendCanvasTiles() and then compressing each resulting canvas tile.
     private sendCompressedTiles(canvas: Canvas, size: SizeType) {
-        const raw: CreateRaw = { width: size.width, height: size.height, channels: 4, premultiplied: true };
+        const raw: CreateRaw = { width: size.width, height: size.height, channels: 4, premultiplied: false };
         canvas
         .toBuffer("raw" as any)
         .then((data: Buffer) => {
@@ -194,7 +194,7 @@ export default class DynamicIcon
         canvas
         .toBuffer("raw" as any)
         .then((data: Buffer) => {
-            sharp(data, { raw: { width: size.width, height: size.height, channels: 4, premultiplied: true } })
+            sharp(data, { raw: { width: size.width, height: size.height, channels: 4, premultiplied: false } })
             .toFormat(format as any, options)
             .toFile(file)
             .catch(e => this.log.error(`Error while saving image for icon '${this.name}' to file "${file}": ${e}`) );
@@ -204,7 +204,7 @@ export default class DynamicIcon
 
     // Saves the canvas contents to a files by breaking up into tiles using Sharp.
     private saveImageTiles(canvas: Canvas, size: SizeType, file: string, format: string, options?: {}) {
-        const raw: CreateRaw = { width: size.width, height: size.height, channels: 4, premultiplied: true };
+        const raw: CreateRaw = { width: size.width, height: size.height, channels: 4, premultiplied: false };
         const pathInfo = pathParse(file);
         const basePath = pathJoin(pathInfo.dir, pathInfo.name);
         canvas

--- a/src/modules/DynamicIcon.ts
+++ b/src/modules/DynamicIcon.ts
@@ -36,7 +36,8 @@ export default class DynamicIcon
     readonly outputCompressionOptions: any = {
         compressionLevel: PluginSettings.defaultOutputCompressionLevel,
         effort: 1,        // MP: 1 actually uses less CPU time than higher values (contrary to what sharp docs suggest) and gives slightly higher compression.
-        palette: true     // MP: Again the docs suggest enabling this would be slower but my tests show a significant speed improvement.
+        palette: true,    // force PNG-8 format output (PNG-24 produces significantly larger file sizes); this is also implied by using `quality` setting.
+        quality: PluginSettings.defaultOutputQuality,  // for PNG-8: use the lowest number of colours needed to achieve given quality
     };
 
     /** The array of elements which will be rendered. */

--- a/src/modules/DynamicIcon.ts
+++ b/src/modules/DynamicIcon.ts
@@ -235,7 +235,6 @@ export default class DynamicIcon
             const activeTxStack: Array<TxStackRecord> = [];
 
             let layer: ILayerElement;
-            let role: LayerRole;
             let tx: Transformation | null = null;
             let layerResetTx: DOMMatrix | null = null;
 
@@ -246,12 +245,9 @@ export default class DynamicIcon
                 if (!layer)
                     continue;
 
-                // The layer "role" determines what we're going to do with it.
-                role = layer.layerRole || LayerRole.Drawable;
-
                 // First handle path producer/consumer and transform type layers.
 
-                if (role & LayerRole.PathProducer) {
+                if (layer.layerRole & LayerRole.PathProducer) {
                     // producers may mutate the path stack by combining with previous path(s)
                     const path = (layer as IPathProducer).getPath(rect, pathStack);
                     pathStack.push(path);
@@ -260,7 +256,7 @@ export default class DynamicIcon
                     //         atx.startIdx == ;
                 }
 
-                if (role & LayerRole.PathConsumer) {
+                if (layer.layerRole & LayerRole.PathConsumer) {
                     // handlers will mutate the path stack
                     // apply any currently active "until reset" scope transforms here before the path is drawn or clipped
                     if (pathStack.length) {
@@ -277,7 +273,7 @@ export default class DynamicIcon
                     //     atx.startIdx = pathStack.length;
                 }
 
-                if (role & LayerRole.Transform) {
+                if (layer.layerRole & LayerRole.Transform) {
                     tx = (layer as Transformation);
                     switch (tx.scope) {
                         case TransformScope.Cumulative:
@@ -319,7 +315,7 @@ export default class DynamicIcon
                 }
 
                 // Anything past here will render directly to the canvas.
-                if (!(role & LayerRole.Drawable))
+                if (!(layer.layerRole & LayerRole.Drawable))
                     continue;
 
                 layerResetTx = null;

--- a/src/modules/DynamicIcon.ts
+++ b/src/modules/DynamicIcon.ts
@@ -287,10 +287,10 @@ export default class DynamicIcon
 
                         case TransformScope.PreviousOne:
                             // If we encounter this tx type in the layers here then it can only apply to a Path
-                            // type layer since the canvas transforms would already be removed by the code below.
+                            // type layer since the canvas transforms would already have been handled by the code below.
                             if (!pathStack.length)
                                 // This would be a "mistake" on the user's part, putting a "previous layer" Tx after something like a style or clip. Which we don't handle gracefully at this time.
-                                this.log.warn("A 'previous layer' scope transformation cannot be applied to layer %d of type '%s' for icon '%s'. ", i+1, layers.at(i-1)?.type, this.name);
+                                this.log.warn("A 'previous layer' scope transformation cannot be applied to layer %d of type '%s' for icon '%s'. ", i, layers.at(i-1)?.constructor?.name, this.name);
                             break;
 
                         case TransformScope.UntilReset:

--- a/src/modules/ImageCache.ts
+++ b/src/modules/ImageCache.ts
@@ -2,10 +2,8 @@
 import sharp from 'sharp';
 import { Image, loadImage, loadImageData, type CanvasDrawable } from 'skia-canvas';
 import { Mutex } from './Mutex';
-import { PluginSettings } from '../common';
-import { elideLeft } from '../utils';
+import { elideLeft, qualifyFilepath } from '../utils';
 import { Logger, logging } from './logging';
-import { isAbsolute as isAbsPath, join as pjoin } from 'path';
 import type { SizeType } from './geometry';
 
 /** Central storage for various image processing options; Set via ImageCache.cacheOptions
@@ -67,12 +65,12 @@ export class ImageCache
     }
 
     private resolveSource(src: string) {
-        const isData = src.startsWith("data:");
-        if (isData)
+        const isB64Data = src.startsWith("data:");
+        if (isB64Data)
             src = src.substring(5);
-        else if (PluginSettings.imageFilesBasePath && !isAbsPath(src))
-            src = pjoin(PluginSettings.imageFilesBasePath, src);
-        return { src: src, isB64Data: isData, isSvg: !isData && ImageCache.isSvg(src) };
+        else
+            src = qualifyFilepath(src);
+        return { src, isB64Data, isSvg: !isB64Data && ImageCache.isSvg(src) };
     }
 
     private async trimCache()

--- a/src/modules/ImageCache.ts
+++ b/src/modules/ImageCache.ts
@@ -1,6 +1,6 @@
 
 import sharp from 'sharp';
-import { loadImage, CanvasImageSource } from 'skia-canvas';
+import { loadImageData, type CanvasDrawable } from 'skia-canvas';
 import { Mutex } from 'async-mutex';
 import { SizeType } from './geometry';
 import { PluginSettings } from '../common';
@@ -28,7 +28,7 @@ class ImageCacheOptions {
     };
 }
 
-export type ImageDataType = CanvasImageSource | null;
+export type ImageDataType = CanvasDrawable | null;
 
 type ImageRecord = {
     image: ImageDataType
@@ -203,9 +203,7 @@ export class ImageCache
                 const {data, info} = await image.ensureAlpha().raw().toBuffer({ resolveWithObject: true });
                 // const meta = await image.metadata();
                 if (data)
-                    return await loadImage(data, { raw:
-                        { width: info.width, height: info.height, /* colorType: (meta.channels == 3 ? 'rgb' : 'rgba'), premultiplied: false */ }
-                    });
+                    return await loadImageData(data, info.width, info.height);
             }
         }
         catch (e) {

--- a/src/modules/ImageCache.ts
+++ b/src/modules/ImageCache.ts
@@ -1,11 +1,12 @@
 
 import sharp from 'sharp';
-import { loadImageData, type CanvasDrawable } from 'skia-canvas';
+import { Image, loadImage, loadImageData, type CanvasDrawable } from 'skia-canvas';
 import { Mutex } from './Mutex';
-import { SizeType } from './geometry';
 import { PluginSettings } from '../common';
+import { elideLeft } from '../utils';
 import { Logger, logging } from './logging';
 import { isAbsolute as isAbsPath, join as pjoin } from 'path';
+import type { SizeType } from './geometry';
 
 /** Central storage for various image processing options; Set via ImageCache.cacheOptions
 Some of these could in theory be controlled via plugin settings or action data. */
@@ -36,8 +37,6 @@ type ImageRecord = {
 }
 class ImageStorage extends Map<string, ImageRecord> {}  // just an alias
 
-let instance: ImageCache;
-
 /**
 Provides a cache for image data originally read from files or other sources, which may possibly be scaled or otherwise transformed before storage.
 The cache key is based on a combination of the requested source file plus the desired size and resize options (as passed to the various methods).
@@ -50,6 +49,7 @@ export class ImageCache
     public static cacheOptions: ImageCacheOptions = new ImageCacheOptions();
 
     // private:
+    private static instance: ImageCache;
     private static cacheHighTide = 25;  // cache can exceed maximum size by this many records before trimming
     private trimTimerId: NodeJS.Timeout | null = null;
     private cache: ImageStorage = new ImageStorage();
@@ -72,7 +72,7 @@ export class ImageCache
             src = src.substring(5);
         else if (PluginSettings.imageFilesBasePath && !isAbsPath(src))
             src = pjoin(PluginSettings.imageFilesBasePath, src);
-        return { src: src, isB64Data: isData };
+        return { src: src, isB64Data: isData, isSvg: !isData && ImageCache.isSvg(src) };
     }
 
     private async trimCache()
@@ -131,7 +131,11 @@ export class ImageCache
 
     /** Get the static global instance of the cache object. See also `globalImageCache` export. */
     public static Instance() {
-        return instance || (instance = new ImageCache());
+        return ImageCache.instance || (ImageCache.instance = new ImageCache());
+    }
+
+    public static isSvg(path: string) {
+        return path.slice(-4)?.toLowerCase() == '.svg';
     }
 
     /** Returns an image from cache if it exists, otherwise loads the image, potentially scales it
@@ -145,13 +149,28 @@ export class ImageCache
             return this.loadImage(src, size, resizeOptions);  // short-circuit for disabled cache
 
         let img: ImageDataType = null;
-        const key: string = this.makeKey(src, size, resizeOptions);
+        let key: string;
+
         await this.mutex.acquire();
-        img = this.getImage_impl(key, meta?.iconName);
+        if (ImageCache.isSvg(src)) {
+            // SVG images loaded as vectors are cached purely by file path as key.
+            img = this.getImage_impl(src, meta?.iconName);
+        }
+        // Hasn't been cached yet, or not an SVG, or could be an SVG which was cached as raster.
         if (!img) {
+            key = this.makeKey(src, size, resizeOptions);
+            img = this.getImage_impl(key, meta?.iconName);
+        }
+        if (!img) {
+            // no image found in cache, load it now
             img = await this.loadImage(src, size, resizeOptions);
-            this.saveImage_impl(key, img, meta);
-            this.log.debug("[%s] Image cache miss for '%s%s'; Returned size: %d x %d", meta?.iconName, (key.length > 75 ? "..." : ""), key.slice(-75), img?.width, img?.height);
+            // `Image` return type means an SVG was loaded as scaleable vector, cache key is just the file path.
+            if (img instanceof Image)
+                key = src;
+            this.saveImage_impl(key!, img, meta);
+            this.log.debug(
+                "[%s] Image cache miss for '%s' size: %d x %d; options: %o; Returned type %s; size: %d x %d",
+                meta?.iconName, elideLeft(src, 60), size.width, size.height, resizeOptions, img?.constructor.name, img?.width, img?.height);
         }
         this.mutex.release();
         return img;
@@ -160,8 +179,12 @@ export class ImageCache
     /** Returns an image from cache if it exists, otherwise returns null.
     Cache key is based on image source and requested size and options.  */
     public async getImage(src: string, size: SizeType, resizeOptions:any = {}): Promise<ImageDataType> {
+        let image: ImageDataType = null;
         await this.mutex.acquire();
-        const image: ImageDataType = this.getImage_impl(this.makeKey(src, size, resizeOptions));
+        if (ImageCache.isSvg(src))
+            image = this.getImage_impl(src);
+        if (!image)
+            image = this.getImage_impl(this.makeKey(src, size, resizeOptions));
         this.mutex.release();
         return image;
     }
@@ -169,18 +192,34 @@ export class ImageCache
     /** Saves an image to cache, possibly replacing any existing entry with the same key.
     Cache key is based on image source and requested size and options. */
     public async saveImage(src: string, size: SizeType, image: ImageDataType, resizeOptions:any = {}, meta?: any) {
+        const key = (image instanceof Image) ? src : this.makeKey(src, size, resizeOptions);
         await this.mutex.acquire();
-        this.saveImage_impl(this.makeKey(src, size, resizeOptions), image, meta);
+        this.saveImage_impl(key, image, meta);
         this.mutex.release();
     }
 
     /** Loads an image from source file and potentially scales it to fit the given size with optional resize options.
-    Set size to {0,0} or resizeOptions.fit to "none" to avoid scaling. Resize options object properties are merged with and override ImageCache.cacheOptions.resizeOptions defaults.
-    Returns null if image loading fails.
+    Set size to {0,0} or resizeOptions.fit to "none" to avoid scaling. Resize options object properties are merged with and override `ImageCache.cacheOptions.resizeOptions` defaults.
+    SVG images successfully loaded with Skia are returned as un-scaled skia-canvas `Image` types, while rasterized formats are returned as `ImageData`.
+    Returns `null` or a `Promise<null>` if image loading fails.
     */
     public async loadImage(src: string, size: SizeType, resizeOptions:any = {}): Promise<ImageDataType> {
+        const srcInfo = this.resolveSource(src);
+        if (srcInfo.isSvg) {
+            // First try loading SVG with Skia because that way we can keep it as vectors.
+            // But Skia SVG parser is more picky than Sharp's, so it may fail, in which case we fall back to try loading it with Sharp and convert to raster.
+            try {
+                return await loadImage(srcInfo.src);
+            }
+            catch (e: any) {
+                if (e?.message?.startsWith("ENOENT")) {
+                    this.log.error(`Image file not found: ${srcInfo.src}`);
+                    return null;
+                }
+                this.log.warn(`There was an error loading SVG image "${srcInfo.src}" as vectors (check that the SVG is fully valid). Will try loading it as raster image instead. The error was: ${e}`)
+            }
+        }
         try {
-            const srcInfo = this.resolveSource(src);
             let image: sharp.Sharp;
             if (srcInfo.isB64Data)
                 image = sharp(Buffer.from(srcInfo.src, 'base64'), ImageCache.cacheOptions.sourceLoadOptions);
@@ -202,7 +241,7 @@ export class ImageCache
             }
         }
         catch (e) {
-            this.log.error(e);
+            this.log.error(`Error trying to load image from source "${elideLeft(srcInfo.src, 100)}": ${e}`);
         }
         return null;
     }
@@ -228,7 +267,7 @@ export class ImageCache
                 if (this.cache.get(k)?.iconNames.has(name)) {
                     this.cache.delete(k);
                     const src = k.split(',')[0];
-                    this.log.info("Removed cached image '%s%s' for icon '%s'.", (src.length > 60 ? "..." : ""), src.slice(-60), name);
+                    this.log.info("Removed cached image '%s' for icon '%s'.", elideLeft(src, 60), name);
                 }
             }
         }

--- a/src/modules/Mutex.ts
+++ b/src/modules/Mutex.ts
@@ -1,0 +1,37 @@
+
+export class Mutex
+{
+    private queue: Array<any> = [];
+    private locked: boolean = false;
+
+    isLocked() { return this.locked; }
+
+    acquire() {
+        return new Promise<void>((resolve) => {
+            if (this.locked) {
+                this.queue.push(resolve);
+            }
+            else {
+                this.locked = true;
+                resolve();
+            }
+        });
+    }
+
+    release() {
+        if (this.queue.length > 0)
+            this.queue.shift()();
+        else
+            this.locked = false;
+    }
+
+    async runExclusive(callback: () => any | Promise<any>) {
+        await this.acquire();
+        try {
+            return await callback();
+        }
+        finally {
+            this.release();
+        }
+    }
+}

--- a/src/modules/ParseState.ts
+++ b/src/modules/ParseState.ts
@@ -1,10 +1,10 @@
 import { Str } from "../utils/consts";
-import { TpActionDataArrayType, TpActionDataRecord, TpActionDataType } from "./types";
+import type { TpActionDataArrayType, TpActionDataRecord } from "./types";
 
 /** A struct to pass meta data as reference to chained action data parsing methods (eg. the various elements' loadFromActionData() methods) */
 export default class ParseState {
-    data: TpActionDataArrayType; // [in] data array to parse
-    pos: number;                 // [in/out] index into data array of current parsing position; incremented for every data field "consumed" by a parser
+    readonly data: TpActionDataArrayType; // [in] data array to parse
+    pos: number;                          // [in/out] index into data array of current parsing position; incremented for every data field "consumed" by a parser
 
     /** Get the whole data array as a flat object with data IDs as keys. Key names are only the last part after '_' separator in ID. */
     get dr(): TpActionDataRecord {
@@ -25,10 +25,11 @@ export default class ParseState {
     /** Transform data array to a flat object with data IDs as keys, starting at array index `start` (default 0).
      * Key names are only the last part after '_' separator in ID. */
     asRecord(start: number = 0, separator: string = Str.IdSep): TpActionDataRecord {
-        return Object.assign({}, ...this.data.map(
-            (d: TpActionDataType, i: number) => {
-                return i >= start ? { [d.id.split(separator).at(-1) as string]: d.value } : {};
-            }
-        ));
+        let ret: TpActionDataRecord = {};
+        for (const e = this.data.length; start < e; ++start) {
+            const d = this.data[start];
+            ret[d.id.split(separator).at(-1) as string] = d.value;
+        }
+        return ret;
     }
 }

--- a/src/modules/ParseState.ts
+++ b/src/modules/ParseState.ts
@@ -1,7 +1,9 @@
 import { Str } from "../utils/consts";
 import type { TpActionDataArrayType, TpActionDataRecord } from "./types";
 
-/** A struct to pass meta data as reference to chained action data parsing methods (eg. the various elements' loadFromActionData() methods) */
+/** A struct to pass meta data as reference to chained action data parsing methods (eg. the various elements' loadFromActionData() methods).
+@internal
+*/
 export default class ParseState {
     readonly data: TpActionDataArrayType; // [in] data array to parse
     pos: number;                          // [in/out] index into data array of current parsing position; incremented for every data field "consumed" by a parser
@@ -28,7 +30,24 @@ export default class ParseState {
         let ret: TpActionDataRecord = {};
         for (const e = this.data.length; start < e; ++start) {
             const d = this.data[start];
-            ret[d.id.split(separator).at(-1) as string] = d.value;
+            const newKey = d.id.split(separator);
+            if (newKey.length > 1)
+                ret[newKey.at(-1)!] = d.value;
+        }
+        return ret;
+    }
+
+    /** Removes everything up to `separator` from key names of `dr` object and returns a new object with new key names and values copied from `dr`.
+        if `removeFromSource` is `true` then the original key is deleted from `dr`. Otherwise `dr` is not modified. */
+    static splitRecordKeys(dr: TpActionDataRecord, separator: string, removeFromSource: boolean = false): TpActionDataRecord {
+        let ret: TpActionDataRecord = {};
+        for (const [key,val] of Object.entries(dr)) {
+            const newKey = key.split(separator, 2);
+            if (newKey.length > 1) {
+                ret[newKey.at(-1)!] = val;
+                if (removeFromSource)
+                    delete dr[key];
+            }
         }
         return ret;
     }

--- a/src/modules/ParseState.ts
+++ b/src/modules/ParseState.ts
@@ -1,5 +1,4 @@
 import { Str } from "../utils/consts";
-import type { TpActionDataArrayType, TpActionDataRecord } from "./types";
 
 /** A struct to pass meta data as reference to chained action data parsing methods (eg. the various elements' loadFromActionData() methods).
 @internal

--- a/src/modules/elements/BarGraph.ts
+++ b/src/modules/elements/BarGraph.ts
@@ -21,7 +21,7 @@ export default class BarGraph implements ILayerElement, IRenderable, IValuedElem
     #values: Array<[number, ContextFillStrokeType]> = []
     #parent: WeakRef<DynamicIcon> | null = null;
 
-    constructor(init?: Partial<BarGraph & {parentIcon: DynamicIcon}>) {
+    constructor(init?: PartialDeep<BarGraph> & {parentIcon?: DynamicIcon}) {
         if (init?.parentIcon)
             this.#parent = new WeakRef(init.parentIcon);
         assignExistingProperties(this, init, 1);

--- a/src/modules/elements/BarGraph.ts
+++ b/src/modules/elements/BarGraph.ts
@@ -1,7 +1,8 @@
-import { IColorElement, ILayerElement, IRenderable, IValuedElement } from '../interfaces';
-import { ColorUpdateType, ParseState, Rectangle, RenderContext2D } from '../';
+import { ColorUpdateType, LayerRole, } from '../';
 import { BrushStyle } from './';
 import { assignExistingProperties, evaluateValue } from '../../utils';
+import type { IColorElement, ILayerElement, IRenderable, IValuedElement } from '../interfaces';
+import type { ParseState, Rectangle, RenderContext2D } from '../';
 
 // Draws a values series as a basic horizontal bar graph onto a canvas context.
 export default class BarGraph implements ILayerElement, IRenderable, IValuedElement, IColorElement
@@ -13,10 +14,11 @@ export default class BarGraph implements ILayerElement, IRenderable, IValuedElem
     backgroundColor: BrushStyle = new BrushStyle("#FFFFFFFF")
     maxExtent: number = 256   // maximum width into which the bars need to fit (or height if an orientation option is added)
 
-    constructor(init?: Partial<BarGraph> | any) { assignExistingProperties(this, init, 0); }
+    constructor(init?: Partial<BarGraph>) { assignExistingProperties(this, init, 0); }
 
     // ILayerElement
-    readonly type: string = "BarGraph";
+    /** @internal */
+    readonly layerRole: LayerRole = LayerRole.Drawable;
 
     // IValuedElement
     // Adds value to current array and shifts values if necessary based on available size and bar width.
@@ -69,7 +71,7 @@ export default class BarGraph implements ILayerElement, IRenderable, IValuedElem
         return this;
     }
 
-    // ILayerElement
+    // IRenderable
     render(ctx: RenderContext2D, rect: Rectangle): void {
         if (!ctx)
             return

--- a/src/modules/elements/BarGraph.ts
+++ b/src/modules/elements/BarGraph.ts
@@ -3,7 +3,7 @@ import { PluginSettings } from '../../common';
 import { BrushStyle } from './';
 import { assignExistingProperties, clamp, evaluateValue } from '../../utils';
 import type { IColorElement, ILayerElement, IRenderable, IValuedElement } from '../interfaces';
-import type { ContextFillStrokeType, DynamicIcon, ParseState, Rectangle, RenderContext2D } from '../';
+import type { DynamicIcon, ParseState, Rectangle } from '../';
 
 /** Draws a values series as a basic vertical bar graph onto a canvas context. */
 export default class BarGraph implements ILayerElement, IRenderable, IValuedElement, IColorElement

--- a/src/modules/elements/BrushStyle.ts
+++ b/src/modules/elements/BrushStyle.ts
@@ -1,24 +1,29 @@
-import { RenderContext2D } from '../';
+import { assignExistingProperties, } from '../../utils';
+import type { RenderContext2D } from '../';
 
 // just a convenience string container class for now, maybe extended later for gradients.
 // TODO: Gradients!
 
+/** Class for applying a fill or stroke style to a Canvas. Currently only supports solid color style. */
 export default class BrushStyle {
     private _color: string = "";
     private _empty: boolean = true;
 
-    constructor(color?: string) {
-        if (color)
-            this.color = color;
+    constructor(init?: Partial<BrushStyle> | string) {
+        if (typeof init == 'string')
+            this.color = init;
+        else
+            assignExistingProperties(this, init, 0);
     }
-
-    readonly type: string = "BrushStyle";
 
     /** true if color string is empty OR represents a transparent color. */
     get isEmpty(): boolean { return this._empty; }
     /** true if color string is empty. */
     get isNull(): boolean { return !this._color.length; }
 
+    /** Set brush style as a solid color.
+
+    Input value must be a hex-encoded color in RGB[A] format (3, 4, 6 or 8 hex digits) starting with '#'. `#R[R]G[G]B[B][A[A]]` */
     set color(v: string) {
         if (!v) {
             this._color = "";
@@ -32,12 +37,15 @@ export default class BrushStyle {
         this._color = v;
         this._empty = (v.length == 9 && v.endsWith("00")) || (v.length == 4 && v.endsWith("0"));
     }
+    /** Returns any color previously set on the `color` property, if any (default is an empty string). */
     get color(): string { return this._color; }
 
+    /** Returns the current style to apply to canvas context properties `fillStyle` or `strokeStyle`. */
     get style(): string | CanvasGradient | CanvasPattern {
         return this._color;
     }
 
+    /** Applies the current `style` property to the given `ctx` as a `fillStyle` if the current `isNull` property returns `false`. */
     render(ctx: RenderContext2D): void {
         if (!this.isNull)
             ctx.fillStyle = this.style;

--- a/src/modules/elements/BrushStyle.ts
+++ b/src/modules/elements/BrushStyle.ts
@@ -1,5 +1,4 @@
 import { assignExistingProperties, } from '../../utils';
-import type { CanvasGradient, CanvasPattern, CanvasTexture, ContextFillStrokeType, RenderContext2D } from '../';
 
 /** Class for storing a fill or stroke style to use on a Canvas context. */
 export default class BrushStyle

--- a/src/modules/elements/BrushStyle.ts
+++ b/src/modules/elements/BrushStyle.ts
@@ -10,7 +10,7 @@ export default class BrushStyle
     #pattern: CanvasPattern | null = null;
     #texture: CanvasTexture | null = null;
 
-    constructor(init?: Partial<BrushStyle> | string) {
+    constructor(init?: PartialDeep<BrushStyle> | string) {
         if (typeof init == 'string')
             this.color = init;
         else

--- a/src/modules/elements/CanvasFilter.ts
+++ b/src/modules/elements/CanvasFilter.ts
@@ -1,6 +1,7 @@
 import { evaluateStringValue } from '../../utils';
-import { ILayerElement, IRenderable, IValuedElement } from '../interfaces';
-import { ParseState, RenderContext2D } from '../';
+import { LayerRole } from '../';
+import type { ILayerElement, IRenderable, IValuedElement } from '../interfaces';
+import type { ParseState, RenderContext2D } from '../';
 
 // Applies a filter string to a canvas context.
 export default class CanvasFilter implements ILayerElement, IRenderable, IValuedElement
@@ -10,7 +11,9 @@ export default class CanvasFilter implements ILayerElement, IRenderable, IValued
     constructor(init?: Partial<CanvasFilter>) { Object.assign(this, init); }
 
     // ILayerElement
-    readonly type: string = "CanvasFilter";
+    /** @internal */
+    readonly layerRole: LayerRole = LayerRole.Drawable;
+
     // returns true if filter string is empty
     get isEmpty(): boolean { return !this.filter; }
 
@@ -38,7 +41,7 @@ export default class CanvasFilter implements ILayerElement, IRenderable, IValued
         return this;
     }
 
-    // ILayerElement
+    // IRenderable
     render(ctx: RenderContext2D): void {
         if (!this.isEmpty)
             ctx.filter = this.filter;

--- a/src/modules/elements/CircularTicks.ts
+++ b/src/modules/elements/CircularTicks.ts
@@ -1,0 +1,94 @@
+import { Alignment, ParseState, Placement, } from '../';
+import { assignExistingProperties, evaluateValue, circularLabelsPath, cirularGaugeTicksPath, parsePlacement, } from '../../utils';
+import { Act, /* DataValue, */ Str } from '../../utils/consts';
+import GaugeTicks, { type LabelMetrics, type TickMetrics, type TickProperties } from './GaugeTicks';  // must be direct import for subclass
+import type { IColorElement, ILayerElement, IRenderable } from '../interfaces';
+import type { RenderContext2D,  } from '../';
+
+/** Implementation of GaugeTicks for drawing ticks/labels along a circular/curved path. */
+export default class CircularTicks extends GaugeTicks implements ILayerElement, IRenderable, IColorElement
+{
+    #start: number = 0;
+    #end: number = 0;
+    #angled: Placement = Placement.NoPlace;
+
+    constructor(init?: PartialDeep<CircularTicks>) {
+        super(init);
+        this.labelsAlign = Alignment.HCENTER;  // always align center by default
+        assignExistingProperties(this, init, 0);
+    }
+
+    /** Returns true if there is nothing to draw: Start angle == end, zero ticks or labels, or all styling would be invisible. */
+    get isEmpty(): boolean {
+        return !this.angleDelta || super.isEmpty;
+    }
+
+    /** Starting angle of ticks curve, in degrees. 0° points north. */
+    get startAngle() { return this.#start; }
+    set startAngle(v: number) {
+        if (v != this.#start) {
+            this.#start = v;
+            this.clearCache();
+        }
+    }
+    /** Ending angle of ticks curve, in degrees. 0° points north. */
+    get endAngle() { return this.#end; }
+    set endAngle(v: number) {
+        if (v != this.#end) {
+            this.#end = v;
+            this.clearCache();
+        }
+    }
+    /** Normalized (0-360) angle difference between `startAngle` and `endAngle`. Read-only. */
+    get angleDelta() {
+        let d = this.endAngle - this.startAngle;
+        while (d < 0)
+            d+= 360;
+        return d;
+    }
+
+    /** Flag indicating if the labels should be auto-rotated to follow the drawing angle from center of gauge.
+        `Placement.Inside` will rotate to face inward, `Placement.Outside` will rotate to face outward, otherwise no auto rotateion is applied.
+        In the first two cases, any further {@link labelsRotate} property adjustment is applied relative to the rotated label. */
+    get labelsAngled(): Placement { return this.#angled; }
+    set labelsAngled(v: Placement | string) {
+        if (v == undefined) return;
+        if (typeof v == 'string')
+            v = parsePlacement(v);
+        if (this.#angled != v) {
+            this.#angled = v;
+            this.clearCache();
+        }
+    }
+
+    /** @internal */
+    loadFromActionData(state: ParseState): CircularTicks {
+        const dr = state.asRecord(state.pos, Act.IconCircularTicks + Str.IdSep);
+        this.startAngle = evaluateValue(dr.start);
+        this.endAngle = evaluateValue(dr.end);
+        this.labelsAngled = dr.label_angled;
+        super.loadFromDataRecord(dr);
+        return this;
+    }
+
+    protected override generateTicksPath(tick: TickProperties, m: TickMetrics) {
+        if (tick.type == 1 && this.angleDelta >= 360)
+            m.ticksCount += tick.count;
+        tick.path = cirularGaugeTicksPath(
+            m.cX, m.cY, m.rX, m.rY, this.startAngle, this.endAngle,
+            m.ticksCount, m.tickLen, tick.place == Placement.Center
+        );
+        // console.log("TICKS PATH:", idx, tick.count, n, this.angleDelta);
+    }
+
+    protected override generateLabelsPath(ctx: RenderContext2D, m: LabelMetrics) {
+        this.labelsPath = circularLabelsPath(ctx,
+            m.cX, m.cY, m.rX + m.offset, m.rY + m.offset,
+            this.startAngle, this.endAngle,
+            this.labels, m.position, this.labelsRotate,
+            (this.#angled == Placement.Inside ? 1 : this.#angled == Placement.Outside ? -1 : 0)
+        );
+        // console.log("LABELS PATH:", m.offset, this.labelsPath.bounds);
+    }
+
+}

--- a/src/modules/elements/CircularTicks.ts
+++ b/src/modules/elements/CircularTicks.ts
@@ -1,9 +1,10 @@
 import { Alignment, ParseState, Placement, } from '../';
-import { assignExistingProperties, evaluateValue, circularLabelsPath, cirularGaugeTicksPath, parsePlacement, } from '../../utils';
-import { Act, /* DataValue, */ Str } from '../../utils/consts';
-import GaugeTicks, { type LabelMetrics, type TickMetrics, type TickProperties } from './GaugeTicks';  // must be direct import for subclass
+import { evaluateValue, circularLabelsPath, cirularGaugeTicksPath, parsePlacement, } from '../../utils';
+import { Act, Str } from '../../utils/consts';
+import GaugeTicks, { type GaugeTicksInit, type LabelMetrics, type TickMetrics, type TickProperties } from './GaugeTicks';  // must be direct import for subclass
 import type { IColorElement, ILayerElement, IRenderable } from '../interfaces';
-import type { RenderContext2D,  } from '../';
+
+export type CircularTicksInit = GaugeTicksInit & PartialDeep<CircularTicks>;
 
 /** Implementation of GaugeTicks for drawing ticks/labels along a circular/curved path. */
 export default class CircularTicks extends GaugeTicks implements ILayerElement, IRenderable, IColorElement
@@ -12,10 +13,10 @@ export default class CircularTicks extends GaugeTicks implements ILayerElement, 
     #end: number = 0;
     #angled: Placement = Placement.NoPlace;
 
-    constructor(init?: PartialDeep<CircularTicks>) {
+    constructor(init?: CircularTicksInit) {
         super(init);
         this.labelsAlign = Alignment.HCENTER;  // always align center by default
-        assignExistingProperties(this, init, 0);
+        super.init(init);
     }
 
     /** Returns true if there is nothing to draw: Start angle == end, zero ticks or labels, or all styling would be invisible. */

--- a/src/modules/elements/CompositionMode.ts
+++ b/src/modules/elements/CompositionMode.ts
@@ -1,12 +1,16 @@
-import { ILayerElement, IRenderable } from '../interfaces';
-import { ParseState, RenderContext2D } from '../';
+import { LayerRole } from '../';
+import type { ILayerElement, IRenderable } from '../interfaces';
+import type { ParseState, RenderContext2D } from '../';
 
 // Applies a globalCompositeOperation to a canvas context.
 export default class CompositionMode implements ILayerElement, IRenderable
 {
     mode: GlobalCompositeOperation = "source-over";
 
-    readonly type: string = "CompositionMode";
+    // ILayerElement
+    /** @internal */
+    readonly layerRole: LayerRole = LayerRole.Drawable;
+
     // returns true mode string is empty
     get isEmpty(): boolean { return !this.mode; }
 
@@ -31,7 +35,7 @@ export default class CompositionMode implements ILayerElement, IRenderable
         return this;
     }
 
-    // ILayerElement
+    // IRenderable
     render(ctx: RenderContext2D): void {
         if (!ctx || this.isEmpty)
             return;

--- a/src/modules/elements/DrawingStyle.ts
+++ b/src/modules/elements/DrawingStyle.ts
@@ -20,7 +20,7 @@ export default class DrawingStyle implements ILayerElement, IPathHandler, IColor
         (only half the line width will protrude around the filled area). */
     strokeOver: boolean = true;
 
-    constructor(init?: Partial<DrawingStyle> ) {
+    constructor(init?: PartialDeep<DrawingStyle> ) {
         this.fill = new BrushStyle(init?.fill);
         this.stroke = new StrokeStyle(init?.stroke);
         this.shadow = new ShadowStyle(init?.shadow);

--- a/src/modules/elements/DrawingStyle.ts
+++ b/src/modules/elements/DrawingStyle.ts
@@ -1,9 +1,9 @@
 import { arraysMatchExactly, assignExistingProperties, parseNumericArrayString, } from '../../utils';
-import { IColorElement, ILayerElement, IPathHandler } from '../interfaces';
 import { ColorUpdateType, LayerRole, ParseState } from '../';
 import { BrushStyle, StrokeStyle, ShadowStyle } from './';
 import { Act, Str } from '../../utils/consts';
-import type { Path2D, Rectangle, RenderContext2D, TpActionDataRecord } from '..';
+import type { IColorElement, ILayerElement, IPathHandler } from '../interfaces';
+import type { Path2D, Rectangle } from '..';
 
 /** Applies a drawing style to a canvas context or `Path2D` objects, which includes all fill, stroke, and shadow attributes. */
 export default class DrawingStyle implements ILayerElement, IPathHandler, IColorElement

--- a/src/modules/elements/DrawingStyle.ts
+++ b/src/modules/elements/DrawingStyle.ts
@@ -1,33 +1,41 @@
-import { assignExistingProperties, parseNumericArrayString, } from '../../utils';
+import { arraysMatchExactly, assignExistingProperties, parseNumericArrayString, } from '../../utils';
 import { IColorElement, ILayerElement, IPathHandler } from '../interfaces';
-import { ColorUpdateType, LayerRole, ParseState, Path2D, Rectangle, RenderContext2D } from '../';
+import { ColorUpdateType, LayerRole, ParseState } from '../';
 import { BrushStyle, StrokeStyle, ShadowStyle } from './';
 import { Act, Str } from '../../utils/consts';
+import type { Path2D, Rectangle, RenderContext2D, TpActionDataRecord } from '..';
 
-// Applies a drawing style to a canvas context, which includes all fill, stroke, and shadow attributes.
+/** Applies a drawing style to a canvas context or `Path2D` objects, which includes all fill, stroke, and shadow attributes. */
 export default class DrawingStyle implements ILayerElement, IPathHandler, IColorElement
 {
+    /** Style to apply as context `fillStyle` property. */
     fill: BrushStyle;
+    /** Defines how to apply the fill style when filling `Path2D` paths. One of: "evenodd" or "nonzero" */
     fillRule: CanvasFillRule = 'nonzero';
-    line: StrokeStyle;
+    /** Styles to apply as context `strokeStyle`, `line*`, and `miterLimit` properties (and `setLineDash()` method). */
+    stroke: StrokeStyle;
+    /** Styles to apply as context `shadow*` properties. */
     shadow: ShadowStyle;
-    strokeOver: boolean = true;  // the stroke is to be drawn on top of the fill if `true`, otherwise under the fill
+    /** When styling `Path2D` paths, the stroke is to be drawn on top of the fill if this property is `true`, otherwise it will draw under the fill
+        (only half the line width will protrude around the filled area). */
+    strokeOver: boolean = true;
 
-    constructor(init?: Partial<DrawingStyle> | any ) {
-        assignExistingProperties(this, init, 0);
-        this.fill = new BrushStyle(init?.color);
-        this.line = new StrokeStyle(init?.stroke);
+    constructor(init?: Partial<DrawingStyle> ) {
+        this.fill = new BrushStyle(init?.fill);
+        this.stroke = new StrokeStyle(init?.stroke);
         this.shadow = new ShadowStyle(init?.shadow);
+        assignExistingProperties(this, init, 0);
     }
 
     // ILayerElement
-    readonly type: string = "DrawingStyle";
+    /** @internal */
     readonly layerRole: LayerRole = LayerRole.PathConsumer;
 
     /** Returns true if there is nothing at all to draw for this style: fill is transparent, stroke is zero size, and there is no shadow.  */
-    get isEmpty(): boolean { return this.fill.isEmpty && this.line.isEmpty && this.shadow.isEmpty; }
+    get isEmpty(): boolean { return this.fill.isEmpty && this.stroke.isEmpty && this.shadow.isEmpty; }
 
     // IColorElement
+    /** @internal */
     setColor(value: string, type: ColorUpdateType): void {
         // Even though ColorUpdateType is a bitfield flag, currently nothing is going to
         // update multiple properties at once, so we can shortcut here.
@@ -36,7 +44,7 @@ export default class DrawingStyle implements ILayerElement, IPathHandler, IColor
                 this.fill.color = value;
                 break;
             case ColorUpdateType.Stroke:
-                this.line.pen.color = value;
+                this.stroke.pen.color = value;
                 break;
             case ColorUpdateType.Shadow:
                 this.shadow.color = value;
@@ -44,33 +52,29 @@ export default class DrawingStyle implements ILayerElement, IPathHandler, IColor
         }
     }
 
-    loadFromActionData(state: ParseState, dataIdPrefix:string = ""): DrawingStyle {
-        dataIdPrefix += Act.IconStyle + Str.IdSep;
-        let lineParsed = false;
-        let atEnd = false;
-        // the incoming data IDs should be structured with a naming convention
-        for (let e = state.data.length; state.pos < e && !atEnd; ) {
-            const data = state.data[state.pos];
-            const dataType = data?.id.split(dataIdPrefix).at(-1);  // last part of the data ID determines its meaning
-            //console.log(state.pos, dataType);
-            switch (dataType) {
+    /** @internal Returns `true` if stroke line width/unit or shadow properties have changed. */
+    loadFromDataRecord(dr: TpActionDataRecord): boolean {
+        let dirty = false;
+        for (const [key, value] of Object.entries(dr)) {
+            switch (key) {
                 case 'fillColor':
-                    this.fill.color = data.value;
+                    this.fill.color = value;
                     break;
                 case 'fillRule':
-                    this.fillRule = data.value as CanvasFillRule;
+                    this.fillRule = <CanvasFillRule>value;
                     break;
                 case 'strokeOver':
                     // "Stroke over", "Stroke under"
-                    this.strokeOver = data.value.endsWith("over");
+                    this.strokeOver = value.endsWith("over");
                     break;
                 case 'shadowColor':
-                    this.shadow.color = data.value;
+                    this.shadow.color = value;
                     break;
                 case 'shadow': {
                     // shadow is specified as (blur [,offsetX[,offsetY]])
-                    const s = [];
-                    if (parseNumericArrayString(data.value, s, 3)) {
+                    const s = [],
+                        shadow = [this.shadow.blur, this.shadow.offset.x, this.shadow.offset.y];
+                    if (parseNumericArrayString(value, s, 3)) {
                         this.shadow.blur = Math.max(s[0], 0);
                         if (s.length > 1)
                             this.shadow.offset.set(s[1], s[2]);
@@ -80,31 +84,35 @@ export default class DrawingStyle implements ILayerElement, IPathHandler, IColor
                     else {
                         this.shadow.resetCoordinates();
                     }
+                    dirty = !arraysMatchExactly(shadow, [this.shadow.blur, this.shadow.offset.x, this.shadow.offset.y])
                     break;
                 }
                 default:
-                    if (!lineParsed && dataType?.startsWith('line_')) {
-                        this.line.loadFromActionData(state, dataIdPrefix);
-                        lineParsed = true;
-                    }
-                    else {
-                        atEnd = true;
-                    }
-                    continue;  // do not increment position counter
+                    continue;
             }
-            ++state.pos;
+            delete dr[key];
         }
+        dirty = this.stroke.loadFromDataRecord(ParseState.splitRecordKeys(dr, "line_")) || dirty;
         // console.dir(this);
+        return dirty;
+    }
+
+    // ILayerElement
+    /** @internal */
+    loadFromActionData(state: ParseState, dataIdPrefix:string = ""): DrawingStyle {
+        this.loadFromDataRecord(state.asRecord(state.pos, dataIdPrefix + Act.IconStyle + Str.IdSep));
         return this;
     }
 
+    /** Applies current fill, stroke, and shadow styling properties to the given canvas `ctx`. `rect` size is used to scale relative-sized stroke width. */
     render(ctx: RenderContext2D, rect?: Rectangle): void {
         this.shadow.render(ctx);
-        this.line.render(ctx, rect);
+        this.stroke.render(ctx, rect);
         this.fill.render(ctx);
     }
 
     // IPathHandler
+    /** Fills and strokes each path in the given array using `DrawingStyle.renderPath()` method. **The given `paths` array is cleared.** */
     renderPaths(paths: Path2D[], ctx: RenderContext2D, rect: Rectangle): void {
         while (paths.length)
             this.renderPath(ctx, paths.shift()!, rect);
@@ -152,9 +160,9 @@ export default class DrawingStyle implements ILayerElement, IPathHandler, IColor
      */
     strokePath(ctx: RenderContext2D, path: Path2D, withShadow: boolean = false, rect?: Rectangle)
     {
-        if (this.line.isEmpty)
+        if (this.stroke.isEmpty)
             return;
-        this.line.render(ctx, rect);
+        this.stroke.render(ctx, rect);
         if (withShadow) {
             this.shadow.saveContext(ctx);
             this.shadow.render(ctx);

--- a/src/modules/elements/DrawingStyle.ts
+++ b/src/modules/elements/DrawingStyle.ts
@@ -69,12 +69,16 @@ export default class DrawingStyle implements ILayerElement, IPathHandler, IColor
                     break;
                 case 'shadow': {
                     // shadow is specified as (blur [,offsetX[,offsetY]])
-                    this.shadow.clear();
                     const s = [];
                     if (parseNumericArrayString(data.value, s, 3)) {
                         this.shadow.blur = Math.max(s[0], 0);
                         if (s.length > 1)
-                            this.shadow.offset.set(s[1], s.length > 2 ? s[2] : s[1]);
+                            this.shadow.offset.set(s[1], s[2]);
+                        else
+                            this.shadow.offset.set(0, 0);
+                    }
+                    else {
+                        this.shadow.resetCoordinates();
                     }
                     break;
                 }

--- a/src/modules/elements/DynamicImage.ts
+++ b/src/modules/elements/DynamicImage.ts
@@ -3,7 +3,7 @@ import { Transformation } from './';
 import { globalImageCache, Image, LayerRole, Rectangle } from '../'
 import { assignExistingProperties, evaluateStringValue } from '../../utils';
 import type { ILayerElement, IRenderable, IValuedElement } from '../interfaces';
-import type { DynamicIcon, ParseState, RenderContext2D, ResizeFitOption, TpActionDataRecord } from '../'
+import type { DynamicIcon, ParseState } from '../'
 
 /**
     This class hold an image source (file path or b64 string) and associated data like processing options and a transformation to apply.
@@ -30,7 +30,7 @@ export default class DynamicImage implements ILayerElement, IRenderable, IValued
     readonly transform: Transformation;
 
     /** Constructor argument requires an object with either `iconName: string` or `parentIcon: DynamicIcon` properties. */
-    constructor(init: RequireAtLeastOne<Partial<DynamicImage & {parentIcon: DynamicIcon, fit: ResizeFitOption}>, 'iconName' | 'parentIcon'>) {
+    constructor(init: RequireAtLeastOne<PartialDeep<DynamicImage & {fit: ResizeFitOption}> & { parentIcon?: DynamicIcon }, 'iconName' | 'parentIcon'>) {
         if (!init?.iconName && !init?.parentIcon)
             throw new Error("'parentIcon' or 'iconName' properties are required in DynamicImage constructor's init object argument.");
         this.transform = new Transformation(init?.transform);

--- a/src/modules/elements/DynamicImage.ts
+++ b/src/modules/elements/DynamicImage.ts
@@ -3,7 +3,7 @@ import { Transformation } from './';
 import { globalImageCache, Image, LayerRole, Rectangle } from '../'
 import { assignExistingProperties, evaluateStringValue } from '../../utils';
 import type { ILayerElement, IRenderable, IValuedElement } from '../interfaces';
-import type { ParseState, RenderContext2D, ResizeFitOption, TpActionDataRecord } from '../'
+import type { DynamicIcon, ParseState, RenderContext2D, ResizeFitOption, TpActionDataRecord } from '../'
 
 /**
     This class hold an image source (file path or b64 string) and associated data like processing options and a transformation to apply.
@@ -29,11 +29,16 @@ export default class DynamicImage implements ILayerElement, IRenderable, IValued
     /** Tranformation to apply to this image when drawn. See {@link Transformation} for details. */
     readonly transform: Transformation;
 
-    constructor(init?: Partial<DynamicImage & {fit: ResizeFitOption}>) {
+    /** Constructor argument requires an object with either `iconName: string` or `parentIcon: DynamicIcon` properties. */
+    constructor(init: RequireAtLeastOne<Partial<DynamicImage & {parentIcon: DynamicIcon, fit: ResizeFitOption}>, 'iconName' | 'parentIcon'>) {
+        if (!init?.iconName && !init?.parentIcon)
+            throw new Error("'parentIcon' or 'iconName' properties are required in DynamicImage constructor's init object argument.");
         this.transform = new Transformation(init?.transform);
-        if (init?.resizeOptions)
+        if (init.parentIcon)
+            this.iconName = init.parentIcon.name;
+        if (init.resizeOptions)
             assignExistingProperties(this.resizeOptions, init?.resizeOptions, 0);
-        else if (init?.fit)
+        else if (init.fit)
             this.resizeOptions.fit = init.fit;
         assignExistingProperties(this, init, 0);
     }

--- a/src/modules/elements/DynamicImage.ts
+++ b/src/modules/elements/DynamicImage.ts
@@ -33,9 +33,10 @@ export default class DynamicImage implements ILayerElement, IRenderable, IValued
     setValue(value: string) {
         // Fixup \ in Windows paths to \\, otherwise they're treated as escapes in the following eval.
         // Ignore any value that contains a / to preserve code (eg. regex), since that's not a legal Windows path character anyway.
-        if (process.platform == "win32" && !value.startsWith("data:") && value.indexOf('/') < 0)
+        const isb64Data = value.startsWith("data:");
+        if (!isb64Data && process.platform == "win32" && value.indexOf('/') < 0)
             value = value.replace(/\\/g, "\\\\");
-        this.source = evaluateStringValue(value.trim());
+        this.source = isb64Data ? value : evaluateStringValue(value.trim());
     }
 
     loadFromActionData(state: ParseState): DynamicImage {

--- a/src/modules/elements/EllipsePath.ts
+++ b/src/modules/elements/EllipsePath.ts
@@ -1,6 +1,6 @@
 
 import { ArcDrawDirection, Point, Path2D } from '../';
-import { evaluateValue, parseArcDirection, round4p, round5p, round6p } from '../../utils';
+import { assignExistingProperties, evaluateValue, parseArcDirection, round4p, round5p, round6p } from '../../utils';
 import { Act, M, Str } from '../../utils/consts'
 import Path from './Path';
 import type { ILayerElement, IPathProducer, IValuedElement } from '../interfaces';
@@ -21,10 +21,10 @@ export default class EllipsePath extends Path implements ILayerElement, IPathPro
     /** Drawing direction, clockwise (0), counter-clockwise (1), or automatic (2) based on value being positive (CW) or negative (CCW). */
     direction: ArcDrawDirection = ArcDrawDirection.CW;
 
-    // constructor(init?: Partial<EllipsePath> | any) { super(init); assignExistingProperties(this, init, 0); }
-
-    // ILayerElement
-    readonly type: string = "EllipsePath";
+    constructor(init?: Partial<EllipsePath>) {
+        super();
+        assignExistingProperties(this, init, 1);
+    }
 
     /** Returns true if the diameter on either axis is empty (width or height are zero) */
     get isEmpty(): boolean {
@@ -54,6 +54,8 @@ export default class EllipsePath extends Path implements ILayerElement, IPathPro
     }
 
     // IPathProducer
+    /** Returns the ellipse as a `Path2D` object, scaled to fit into `rect` bounds (if size units are relative), and combined
+        with any paths in the `pathStack` according to value of the {@link operation} property. */
     getPath(rect: Rectangle, pathStack: Array<Path2D>): Path2D
     {
         if (rect.isEmpty)

--- a/src/modules/elements/EllipsePath.ts
+++ b/src/modules/elements/EllipsePath.ts
@@ -1,10 +1,12 @@
 
 import { ArcDrawDirection, Point, Path2D } from '../';
-import { assignExistingProperties, evaluateValue, parseArcDirection, round4p, round5p, round6p } from '../../utils';
+import { evaluateValue, parseArcDirection, round4p, round5p, round6p } from '../../utils';
 import { Act, M, Str } from '../../utils/consts'
-import Path from './Path';
+import Path, { type PathInit } from './Path';
 import type { ILayerElement, IPathProducer, IValuedElement } from '../interfaces';
 import type { ParseState, Rectangle } from '../';
+
+export type EllipsePathInit = PathInit & PartialDeep<EllipsePath>;
 
 /** Creates a full or partial ellipse/circle/arc path of given diameter, start and end angle values,
     draw direction, and optional rotation around center. Essentially a proxy for `Path2D.ellipse()` method.
@@ -21,9 +23,9 @@ export default class EllipsePath extends Path implements ILayerElement, IPathPro
     /** Drawing direction, clockwise (0), counter-clockwise (1), or automatic (2) based on value being positive (CW) or negative (CCW). */
     direction: ArcDrawDirection = ArcDrawDirection.CW;
 
-    constructor(init?: PartialDeep<EllipsePath>) {
+    constructor(init?: EllipsePathInit) {
         super();
-        assignExistingProperties(this, init, 1);
+        super.init(init);
     }
 
     /** Returns true if the diameter on either axis is empty (width or height are zero) */

--- a/src/modules/elements/EllipsePath.ts
+++ b/src/modules/elements/EllipsePath.ts
@@ -21,7 +21,7 @@ export default class EllipsePath extends Path implements ILayerElement, IPathPro
     /** Drawing direction, clockwise (0), counter-clockwise (1), or automatic (2) based on value being positive (CW) or negative (CCW). */
     direction: ArcDrawDirection = ArcDrawDirection.CW;
 
-    constructor(init?: Partial<EllipsePath>) {
+    constructor(init?: PartialDeep<EllipsePath>) {
         super();
         assignExistingProperties(this, init, 1);
     }

--- a/src/modules/elements/FreeformPath.ts
+++ b/src/modules/elements/FreeformPath.ts
@@ -9,52 +9,97 @@ import Path from './Path';
     A path can be specified with either an array of points or an SVG syntax path.
     When using arrays of points, multiple line segments can be specified by wrapping
     each segment in its own array.
-
-    Path syntax:
-        "x,y" || "[x,y]" - single point (<pt>), y is optional (defaults to x)
-        "<pt>, <pt>, ..." - Multiple points on one path; at least 2 points are required
-        "[  <pt>, <pt>, ...], [ <pt>, <pt>, ...], ..." - Multiple paths
-        "M..." or "m..." - An SVG path; The action data is evaluated as an interpolated string for embedded JS ('${...}')
-        "() => {...}" - A function returning either a points array or SVG path string.
  */
 export default class FreeformPath extends Path implements ILayerElement, IPathProducer, IValuedElement
 {
-    relativeUnits: boolean = false;  // when true, path is scaled to drawing rectangle
-    closePath: boolean = false;      // if a `closePath()` should be used at the of each line segment (ignored for SVG paths, use 'Z'/'z')
+    /** When `true`, path is scaled to size of drawing rectangle. */
+    relativeUnits: boolean = false;  //
+    /** `true` if a `closePath()` should be used at the of each line segment when crating
+        paths from arrays of points (ignored for SVG paths, use 'Z'/'z' instead). */
+    closePath: boolean = false;      //
 
-    private lines: Array<PointType[]> = [];
-    private svgPath: string | null = null;
-    private lastInput: string = "";  // cache to avoid reparsing path if input unchanged
+    #lines: Array<PointType[]> = [];
+    #svgPath: string | null = null;
+    #lastInput: string = "";  // cache to avoid reparsing path if input unchanged
 
-    constructor(init?: Partial<FreeformPath> | any) {
-        super(Object.assign({}, { alignment: Alignment.TOP | Alignment.LEFT }, init));
-        assignExistingProperties(this, init, 0);
+    constructor(init?: Partial<FreeformPath>) {
+        super({ alignment: Alignment.TOP | Alignment.LEFT });
+        if (init?.path) {
+            if (init.path instanceof Path2D)
+                this.path = init.path;
+            delete init.path;
+        }
+        assignExistingProperties(this, init, 1);
     }
 
-    // ILayerElement
-    readonly type: string = "FreeformPath";
-
-    /** Returns true if there are fewer than 2 points to draw and has no SVG path. */
+    /** Returns `true` if there are fewer than 2 points to draw and has no SVG path. */
     get isEmpty(): boolean {
-        return !this.svgPath && (!this.lines?.length || this.lines[0].length < 2);
+        return !this.#svgPath && (!this.#lines?.length || this.#lines[0].length < 2);
     }
 
-    // IValuedElement
-    // Parses and sets the path value from action data, with minimal validation.
-    // First checks value against the cached last value. Returns false if the path hasn't changed or couldn't be loaded.
-    setValue(value: string): boolean
+    /** Returns the currently cached Path2D object, if any, or an empty Path2D otherwise. */
+    get path(): Path2D { return this.cache.path ?? new Path2D(); }
+    /** Explicitly sets the cached `Path3D` object to `path`.
+        A new path will not be re-generated unless `svgPath` or `lines` properties are set, or cache explicitly is cleared with `clearCache()`.
+        The path will still be scaled and aligned in {@link getPath()}, if needed, and the new scaled/aligned path will then be cached. */
+    set path(path: Path2D) {
+        this.cache.path = path;
+        this.cache.size = null;
+    }
+
+    /** Set or get the path definition as an SVG path string.
+        Reading the property returns empty unless the property was explicitly set previously. */
+    get svgPath() { return this.#svgPath ?? ''; }
+    set svgPath(path: string) {
+        this.#svgPath = path;
+        this.clearCahe();
+    }
+
+    /** Set or get the path definition as an array or line coordinates.
+        Reading the property returns an empty array unless the property was explicitly set previously. */
+    get lines(): Array<PointType[]> { return this.#lines; }
+    set lines(lines: Array<PointType[]>) {
+        this.#lines = lines;
+        this.clearCahe();
+    }
+
+    /** Appends an array of points to the current lines array. */
+    appendLine(line: Array<PointType>) {
+        this.#lines.push(line);
+        this.clearCahe();
+    }
+
+    /** Clears all coordinates in the current lines array. */
+    clearLines() {
+        this.#lines.length = 0;
+        this.clearCahe();
+    }
+
+    /** Parses and sets the path from an evaluated string value, with minimal validation.
+        First checks value against the cached last value. Returns `false` if the path hasn't changed or couldn't be loaded.
+
+        Accepted path values:
+        ```
+            "x,y" || "[x,y]" - single point (<pt>), y is optional (defaults to x)
+            "<pt>, <pt>, ..." - Multiple points on one path; at least 2 points are required
+            "[  <pt>, <pt>, ...], [ <pt>, <pt>, ...], ..." - Multiple paths
+            "M..." or "m..." - An SVG path; The action data is evaluated as an interpolated string for embedded JS ('${...}')
+            "() => {...}" - A function returning either a points array or an SVG path string.
+        ```
+    */
+    setPathFromString(value: string): boolean
     {
-        if (value == this.lastInput)
+        if (value == this.#lastInput)
             return false;
-        this.lastInput = value;
-        this.lines.length = 0;
+        this.#lastInput = value;
+        this.#lines.length = 0;
 
         if (value.trimStart()[0].toUpperCase() == "M" ) {
-            this.svgPath = evaluateStringValue(value);
+            this.#svgPath = evaluateStringValue(value);
             return true;
         }
 
-        this.svgPath = null;
+        this.#svgPath = null;
         let result: Array<any> = evaluateValueAsArray(value);
         if (typeof result[0] == 'function') {
             result = [result[0]()];
@@ -72,13 +117,18 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
             return true;
         }
         if (typeof first == 'string' && first.trimStart()[0].toUpperCase() == "M") {
-            this.svgPath = first;
+            this.#svgPath = first;
             return true;
         }
         logging().getLogger('plugin').warn("Path value '%s' must be numeric, an array, or a string starting with 'M'.", first);
         return false;
     }
 
+    // IValuedElement
+    /** @internal */
+    setValue(value: string) { return this.setPathFromString(value); }
+
+    /** @internal */
     loadFromActionData(state: ParseState, statePrefix: string = "path"): FreeformPath
     {
         const dr = state.asRecord(state.pos, statePrefix + Str.IdSep);
@@ -93,18 +143,18 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
         }
         if (dr.close && parseBoolFromValue(dr.close) != this.closePath) {
             this.closePath = !this.closePath;
-            dirty = !this.svgPath || dirty; // closePath is ignored for SVG paths anyway
+            dirty = !this.#svgPath || dirty; // closePath is ignored for SVG paths anyway
         }
 
         if (dirty)
-            this.cache.clear();
+            this.clearCahe();
         return this;
     }
 
     private parsePoints(line: Array<number | number[]>, lineIdx = 0)
     {
-        if (lineIdx >= this.lines.length)
-            this.lines[lineIdx] = [];
+        if (lineIdx >= this.#lines.length)
+            this.#lines[lineIdx] = [];
         for (let i = 0; i < line.length; ++i) {
             let val = line[i];
             // logging().getLogger('plugin').debug(`Value ${val} @ ${i} line ${lineIdx} type ${typeof val}`);
@@ -116,7 +166,7 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
             else if (typeof val == 'number') {
                 val = round4p(val);
                 const y = typeof line[i + 1] == 'number' ? round4p(line[++i] as number) : val;
-                this.lines[lineIdx].push(Point.new(val, y));
+                this.#lines[lineIdx].push(Point.new(val, y));
             }
             else {
                 logging().getLogger('plugin').warn("Value %s at position %d of line %d must be numeric or an array but it is: %s", val, i+1, lineIdx+1, typeof val);
@@ -124,14 +174,14 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
         }
     }
 
-    private drawPath()
+    private createPath()
     {
-        if (this.svgPath) {
-            this.cache.path = new Path2D(this.svgPath);
+        if (this.#svgPath) {
+            this.cache.path = new Path2D(this.#svgPath);
         }
         else {
             this.cache.path = new Path2D();
-            for (const line of this.lines) {
+            for (const line of this.#lines) {
                 if (!Array.isArray(line) || line.length < 2)
                     continue;
                 let pt = line[0];
@@ -147,13 +197,15 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
     }
 
     // IPathProducer
+    /** Returns the defined path as a `Path2D` object, scaled to fit into `rect` bounds (if size units are relative), and combined
+        with any paths in the `pathStack` according to value of the {@link operation} property. */
     getPath(rect: Rectangle, pathStack?: Array<Path2D>): Path2D
     {
         if (!this.cache.path)
-            this.drawPath();
+            this.createPath();
 
         if (this.cache.isDirtyForSize(rect.size)) {
-            // Scale the complete path if using relative unit size. Recompute and cache the result when 'rect' dimentions change.
+            // Scale the complete path if using relative unit size. Recompute and cache the result when 'rect' dimensions change.
             if (this.relativeUnits) {
                 const sclX = round4p(this.cache.size ? rect.width / this.cache.size.width : rect.width * 0.01),
                     sclY = round4p(this.cache.size ? rect.height / this.cache.size.height : rect.height * 0.01);

--- a/src/modules/elements/FreeformPath.ts
+++ b/src/modules/elements/FreeformPath.ts
@@ -1,5 +1,5 @@
 import { ILayerElement, IPathProducer, IValuedElement } from '../interfaces';
-import { Alignment, logging, ParseState, Path2D, Point, PointType, Rectangle, Size, UnitValue } from '..';
+import { Alignment, logging, ParseState, Path2D, Point, PointType, Rectangle, UnitValue } from '..';
 import { assignExistingProperties, evaluateStringValue, evaluateValueAsArray, parseBoolFromValue, round4p } from '../../utils';
 import { Str } from '../../utils/consts';
 import Path from './Path';
@@ -211,9 +211,8 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
                     sclY = round4p(this.cache.size ? rect.height / this.cache.size.height : rect.height * 0.01);
                 this.cache.path = this.cache.path!.transform(sclX, 0, 0, sclY, 0, 0);
             }
-            const b = this.cache.path!.bounds;
-            const offset = super.computeOffset(Size.new(b.width, b.height), rect);
-            if (!Point.isNull(offset))
+            const offset = super.computeOffset(Rectangle.fromBounds(this.cache.path!.bounds), rect);
+            if (!Point.fuzzyIsNull(offset))
                 this.cache.path = this.cache.path!.offset(offset.x, offset.y);
             this.cache.size = rect.size;
             // logging().getLogger('plugin').debug('size:\n%O\ncacheSize:\n%O\npath:\n%O', rect.size, this.cache.size, this.cache.path!.edges);

--- a/src/modules/elements/FreeformPath.ts
+++ b/src/modules/elements/FreeformPath.ts
@@ -52,7 +52,7 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
     get svgPath() { return this.#svgPath ?? ''; }
     set svgPath(path: string) {
         this.#svgPath = path;
-        this.clearCahe();
+        this.clearCache();
     }
 
     /** Set or get the path definition as an array or line coordinates.
@@ -60,19 +60,19 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
     get lines(): Array<PointType[]> { return this.#lines; }
     set lines(lines: Array<PointType[]>) {
         this.#lines = lines;
-        this.clearCahe();
+        this.clearCache();
     }
 
     /** Appends an array of points to the current lines array. */
     appendLine(line: Array<PointType>) {
         this.#lines.push(line);
-        this.clearCahe();
+        this.clearCache();
     }
 
     /** Clears all coordinates in the current lines array. */
     clearLines() {
         this.#lines.length = 0;
-        this.clearCahe();
+        this.clearCache();
     }
 
     /** Parses and sets the path from an evaluated string value, with minimal validation.
@@ -147,7 +147,7 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
         }
 
         if (dirty)
-            this.clearCahe();
+            this.clearCache();
         return this;
     }
 

--- a/src/modules/elements/FreeformPath.ts
+++ b/src/modules/elements/FreeformPath.ts
@@ -1,8 +1,10 @@
-import { ILayerElement, IPathProducer, IValuedElement } from '../interfaces';
-import { Alignment, logging, ParseState, Path2D, Point, PointType, Rectangle, UnitValue } from '..';
-import { assignExistingProperties, evaluateStringValue, evaluateValueAsArray, parseBoolFromValue, round4p } from '../../utils';
+import { Alignment, logging, type ParseState, Path2D, Point, Rectangle, UnitValue } from '..';
+import { evaluateStringValue, evaluateValueAsArray, parseBoolFromValue, round4p } from '../../utils';
 import { Str } from '../../utils/consts';
-import Path from './Path';
+import Path, { type PathInit } from './Path';
+import type { ILayerElement, IPathProducer, IValuedElement } from '../interfaces';
+
+export type FreeformPathInit = PathInit & PartialDeep<FreeformPath>;
 
 /**
     An element for drawing paths/shapes, eg. for styled drawing or for clipping.
@@ -22,14 +24,14 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
     #svgPath: string | null = null;
     #lastInput: string = "";  // cache to avoid reparsing path if input unchanged
 
-    constructor(init?: PartialDeep<FreeformPath>) {
+    constructor(init?: FreeformPathInit) {
         super({ alignment: Alignment.TOP | Alignment.LEFT });
         if (init?.path) {
             if (init.path instanceof Path2D)
                 this.path = init.path;
             delete init.path;
         }
-        assignExistingProperties(this, init, 1);
+        super.init(init);
     }
 
     /** Returns `true` if there are fewer than 2 points to draw and has no SVG path. */

--- a/src/modules/elements/FreeformPath.ts
+++ b/src/modules/elements/FreeformPath.ts
@@ -37,12 +37,12 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
         return !this.#svgPath && (!this.#lines?.length || this.#lines[0].length < 2);
     }
 
-    /** Returns the currently cached Path2D object, if any, or an empty Path2D otherwise. */
-    get path(): Path2D { return this.cache.path ?? new Path2D(); }
+    /** Returns the currently cached Path2D object, if any, or `null` otherwise. */
+    get path(): Path2D | null { return this.cache.path; }
     /** Explicitly sets the cached `Path3D` object to `path`.
-        A new path will not be re-generated unless `svgPath` or `lines` properties are set, or cache explicitly is cleared with `clearCache()`.
+        A new path will not be re-generated unless `svgPath` or `lines` properties are set, or cache is explicitly cleared with `clearCache()`.
         The path will still be scaled and aligned in {@link getPath()}, if needed, and the new scaled/aligned path will then be cached. */
-    set path(path: Path2D) {
+    set path(path: Path2D | null) {
         this.cache.path = path;
         this.cache.size = null;
     }

--- a/src/modules/elements/FreeformPath.ts
+++ b/src/modules/elements/FreeformPath.ts
@@ -22,7 +22,7 @@ export default class FreeformPath extends Path implements ILayerElement, IPathPr
     #svgPath: string | null = null;
     #lastInput: string = "";  // cache to avoid reparsing path if input unchanged
 
-    constructor(init?: Partial<FreeformPath>) {
+    constructor(init?: PartialDeep<FreeformPath>) {
         super({ alignment: Alignment.TOP | Alignment.LEFT });
         if (init?.path) {
             if (init.path instanceof Path2D)

--- a/src/modules/elements/GaugeTicks.ts
+++ b/src/modules/elements/GaugeTicks.ts
@@ -1,0 +1,507 @@
+import { Alignment, ColorUpdateType, LayerRole, ParseState, Path2D, Placement, Rectangle, UnitValue } from '../';
+import { arraysMatchExactly, assignExistingProperties, evaluateStringValue, evaluateValue, parseAlignmentFromValue, parsePlacement } from '../../utils';
+import { ALIGNMENT_ENUM_NAMES, Str } from '../../utils/consts';
+import { BrushStyle, StrokeStyle, StyledText } from './';
+import SizedElement from './SizedElement';  // must be direct import for subclass
+import type { RenderContext2D, TpActionDataRecord,  } from '../';
+
+export type TickProperties = {
+    type: 0|1
+    count: number
+    len: UnitValue
+    place: Placement
+    path: Path2D | null
+    stroke: StrokeStyle
+}
+
+export type PathMetrics = ReturnType<GaugeTicks['metrics']>
+export type TickMetrics = PathMetrics & { ticksCount:number, tickLen: number|number[] };
+export type LabelMetrics = PathMetrics & {offset: number, position: 1|-1};
+
+class Cache {
+    rect = new Rectangle();    // dimensions that the current paths were last scaled/aligned into
+    bounds = new Rectangle();  // last calculated path bounds after scaling and alignment
+    scale = 1;                 // last calculated scaling factor for `rect` to `bounds` difference, to be applied to canvas context
+    lastLabelsValue = "";      // the last parsed "values" action data string, to know if it needs re-parsing into new labels array
+    get isNull() { return this.rect.isNull; }
+    clear() { this.rect.clear(); }
+    isDirty(rect: Rectangle) { return this.isNull || !this.rect.fuzzyEquals(rect); }
+}
+
+/**
+    Abstract base class for drawing "tick" marks and/or value labels, for use in a gauge indicator.
+    Ticks can be split into "major" and "minor" divisions with separate spacing, size and styling options.
+    Label text, font, color, and other presentation properties are configured independently from the tick marks.
+*/
+export default abstract class GaugeTicks extends SizedElement
+{
+    readonly #cache = new Cache();
+    readonly #ticks: [TickProperties, TickProperties];
+    readonly #labels = {
+        place: Placement.Inside,
+        align: Alignment.NONE,  // horizontal, NONE for auto alignment, only used by linear
+        rotate: <number> 0,     // different meanings for linear and circular
+        padding: <number> 0,    // user-specified offset from automatic placement
+        font: <string> "",      // full CSS font spec
+        spacing: <UnitValue> new UnitValue(0, "px"),
+        fill: <BrushStyle> null!,
+        labels: <Array<string>> [],  // label values, if any; length is used to determine spacings
+        path: <Path2D | null> null,  // generated Path2D for the labels, if any
+    };
+
+    constructor(init?: PartialDeep<GaugeTicks>) {
+        super();
+        this.#ticks = [
+            this.#initTickRecord(0, init?.majTicksStroke),
+            this.#initTickRecord(1, init?.minTicksStroke),
+        ];
+        this.#labels.fill = new BrushStyle(init?.labelsStyle);
+        assignExistingProperties(this, init, 0);
+    }
+
+    #initTickRecord(type: 0|1, strokeInit?: PartialDeep<StrokeStyle>): TickProperties {
+        return {
+            type,
+            count: 0,
+            len: new UnitValue(0, "%"),
+            place: Placement.Inside,
+            path: null,
+            stroke: new StrokeStyle(strokeInit),
+        }
+    }
+
+    // ILayerElement
+    /** @internal */
+    readonly layerRole: LayerRole = LayerRole.Drawable;
+
+    /** Returns true if there is nothing to draw: Zero ticks and labels, zero width or height, or all styling would be invisible. */
+    get isEmpty(): boolean {
+        return (!this.majTicksCount && !this.hasLabels)
+            || this.width.value == 0
+            || this.height.value == 0
+            || (this.majTicksStroke.isEmpty && this.minTicksStroke.isEmpty && this.#labels.fill.isEmpty);
+    }
+    /** Returns `true` if there are any labels to be drawn. */
+    get hasLabels(): boolean {
+        return this.labels.length > 0;
+    }
+
+    protected get ticks() { return this.#ticks; }
+    protected get majTicks() { return this.#ticks[0]; }
+    protected get minTicks() { return this.#ticks[1]; }
+
+    /** Total number of major tick marks to draw along the curve. This will also determine the spacing (number of degrees) between ticks. */
+    get majTicksCount() { return this.majTicks.count; }
+    set majTicksCount(v: number) { this.setTickCount(this.majTicks, v); }
+    /** Length of each major tick mark, in either % or px units. Relative size is calculated based on overall image size. */
+    get majTicksLen(): number { return this.majTicks.len.value; }
+    set majTicksLen(v: number | string) { this.setTickLen(this.majTicks, v); }
+    /** Length unit for each major tick mark, either `%` or `px`. */
+    get majTicksLenUnit() { return this.majTicks.len.unit; }
+    set majTicksLenUnit(v: string) { this.setTickLenUnit(this.majTicks, v); }
+    /** Configures in which direction to draw major tick marks relative to the curve radius. `Inside` will draw from curve radius to the inside of the circle,
+        `Outside` will draw from radius towards the outside, and `Center` will split the difference with each mark being centered along the radius. */
+    get majTicksPlace(): Placement { return this.majTicks.place; }
+    set majTicksPlace(v: Placement | string) { this.setTickPlace(this.majTicks, v); }
+    /** Major tick marks `StrokeStyle` object. Read-only. */
+    get majTicksStroke(): StrokeStyle { return this.majTicks.stroke; };
+    /** Major tick marks stroke color. */
+    get majTicksColor() { return this.majTicksStroke.pen.color; }
+    set majTicksColor(v: string) { this.majTicksStroke.pen.color = v; }
+    /** Gets or sets the `Path2D` object representing the major ticks marks to be drawn. */
+    get majTicksPath() { return this.majTicks.path; }
+    set majTicksPath(v: Path2D | null) { this.majTicks.path = v; }
+
+
+    /** The number of minor tick marks to draw between each major tick (not a total number). This will also determine the spacing (number of degrees) between minor ticks. */
+    get minTicksCount() { return this.minTicks.count; }
+    set minTicksCount(v: number) { this.setTickCount(this.minTicks, v); }
+    /** Length of each minor tick mark, in either % or px units. Relative size is calculated based on overall image size. */
+    get minTicksLen(): number { return this.minTicks.len.value; }
+    set minTicksLen(v: number | string) { this.setTickLen(this.minTicks, v); }
+    /** Length unit for each minor tick mark, either `%` or `px`. */
+    get minTicksLenUnit() { return this.minTicks.len.unit; }
+    set minTicksLenUnit(v: string) { this.setTickLenUnit(this.minTicks, v); }
+    /** Configures in which direction to draw minor tick marks relative to the curve radius. `Inside` will draw from curve radius to the inside of the circle,
+        `Outside` will draw from radius towards the outside, and `Center` will split the difference with each mark being centered along the radius. */
+    get minTicksPlace(): Placement { return this.minTicks.place; }
+    set minTicksPlace(v: Placement | string) { this.setTickPlace(this.minTicks, v); }
+    /** Minor tick marks `StrokeStyle` object. Read-only. */
+    get minTicksStroke(): StrokeStyle { return this.minTicks.stroke; };
+    /** Minor tick marks stroke color. */
+    get minTicksColor() { return this.minTicks.stroke.pen.color; }
+    set minTicksColor(v: string) {
+        this.minTicks.stroke.pen.color = v;
+    }
+    /** Gets or sets the `Path2D` object representing the minor ticks marks to be drawn. */
+    get minTicksPath() { return this.minTicks.path; }
+    set minTicksPath(v: Path2D | null) { this.minTicks.path = v; }
+
+
+    /** Array of strings to be used as label text. Empty for no labels.
+        The individual label values will be distributed evenly along the curve from `startAngle` to `endAngle` (inclusive). */
+    get labels() { return this.#labels.labels; }
+    set labels(v: string[]) {
+        if (!v) v = [];
+        if (!arraysMatchExactly(v, this.#labels.labels)) {
+            this.#labels.labels = v;
+            this.clearCache();
+            // console.log(v);
+        }
+    }
+    /** Controls label placement, `Placement.Inside` to put labels inside the curve, or `Placement.Outside` to place them outside the curve. */
+    get labelsPlace(): Placement { return this.#labels.place; }
+    set labelsPlace(v: Placement | string) {
+        if (v == undefined) return;
+        if (typeof v == 'string')
+            v = parsePlacement(v, Placement.Inside);
+        if (v != this.#labels.place) {
+            this.#labels.place = v;
+            this.clearCache();
+        }
+    }
+
+    get labelsAlign(): Alignment { return this.#labels.align; }
+    set labelsAlign(v: Alignment | string) {
+        if (v == undefined) return;
+        if (typeof v == 'string')
+            v = parseAlignmentFromValue(v, Alignment.H_MASK);
+        if (v != this.#labels.align) {
+            this.#labels.align = v;
+            this.clearCache();
+        }
+    }
+
+    /** Controls label rotation.
+        For linear marks this sets rotation from horizontal, in degrees.
+        For circular, 0 = no rotation, 1 = rotate to inside, -1 = rotate to outside. */
+    get labelsRotate():number { return this.#labels.rotate; }
+    set labelsRotate(v: number | string) {
+        if (v == undefined) return;
+        if (typeof v == 'string')
+            v = parseFloat(v) || 0;
+        if (v != this.#labels.rotate) {
+            this.#labels.rotate = v;
+            this.clearCache();
+        }
+    }
+
+    /** Expands or contracts the space between label text and the tick marks. Expressed as percent of overall image size. Default is `0`. */
+    get labelsPadding():number { return this.#labels.padding; }
+    set labelsPadding(v: number | string) {
+        if (v == undefined) return;
+        if (typeof v == 'string')
+            v = parseFloat(v) || 0;
+        if (v != this.#labels.padding) {
+            this.#labels.padding = v;
+            this.clearCache();
+        }
+    }
+    /** CSS font specification for labels text. */
+    get labelsFont() { return this.#labels.font; }
+    set labelsFont(v: string) {
+        if (v != this.#labels.font) {
+            this.#labels.font = v;
+            this.clearCache();
+        }
+    }
+    /** Letter spacing property expressed as a CSS `length` value, eg: "2px" or "1em". Default is `0px`. */
+    get labelsSpacing() { return this.#labels.spacing.toString(); }
+    set labelsSpacing(v: string) {
+        if (!v) return;
+        if (this.labelsSpacing != v) {
+            this.#labels.spacing.setFromString(v);
+            this.clearCache();
+        }
+    }
+    /** Labels fill `BrushStyle`. Read-only. */
+    get labelsStyle() { return this.#labels.fill; }
+    /** Labels fill color. */
+    get labelsColor() { return this.#labels.fill.color; }
+    set labelsColor(v: string) {
+        this.#labels.fill.color = v;
+    }
+    /** Gets or sets the `Path2D` object representing the labels to be drawn. */
+    get labelsPath() { return this.#labels.path; }
+    set labelsPath(v: Path2D | null) { this.#labels.path = v; }
+
+    // IColorElement
+    /** @internal `ColorUpdateType.Fill` set label color and `ColorUpdateType.Stroke` sets stroke color for both major and minor ticks. */
+    setColor(value: string, type: ColorUpdateType): void {
+        if (type & ColorUpdateType.Fill)
+            this.labelsColor = value;
+        if (type & ColorUpdateType.Stroke) {
+            this.majTicksColor = value;
+            this.minTicksColor = value;
+        }
+    }
+
+    protected clearCache() {
+        this.#cache.clear();
+        // console.trace("Cache cleared");
+    }
+
+    protected setTickCount(t:TickProperties, v:number) {
+        if (v == undefined) return;
+        if (v != t.count) {
+            t.count = v;
+            this.clearCache();
+        }
+    }
+    protected setTickLen(t:TickProperties, v:number | string) {
+        if (v == undefined) return;
+        if (typeof v == 'string') {
+            const u = UnitValue.fromString(v);
+            this.setTickLen(t, u.value);
+            this.setTickLenUnit(t, u.unit);
+        }
+        else if (v != t.len.value) {
+            t.len.value = v;
+            this.clearCache();
+        }
+    }
+    protected setTickLenUnit(t:TickProperties, v:string) {
+        if (!v) return;
+        if (v != t.len.unit) {
+            t.len.unit = v;
+            this.clearCache();
+        }
+    }
+    protected setTickPlace(t:TickProperties, v:Placement | string) {
+        if (v == undefined) return;
+        if (typeof v == 'string')
+            v = parsePlacement(v, t.type == 0 ? Placement.Inside : this.majTicksPlace);
+        if (v != t.place) {
+            t.place = v;
+            this.clearCache();
+        }
+    }
+
+    protected loadTickData(idx: 0|1, record: TpActionDataRecord) {
+        const dr = ParseState.splitRecordKeys(record, (idx == 0 ? 'maj' : 'min') + Str.IdSep, true),
+            t = this.#ticks[idx];
+        this.setTickCount(t, evaluateValue(dr.count));
+        if (t.count) {
+            this.setTickLen(t, evaluateValue(dr.len));
+            this.setTickLenUnit(t, dr.len_unit);
+            this.setTickPlace(t, dr.place);
+            t.stroke.loadFromDataRecord(ParseState.splitRecordKeys(dr, "line_"));
+        }
+    }
+
+    /** @internal */
+    protected loadFromDataRecord(dr: TpActionDataRecord) {
+        if (super.loadFromDataRecord(dr))
+            this.clearCache();
+
+        this.loadTickData(0, dr);
+        this.loadTickData(1, dr);
+
+        const labelValue = dr.label_value.trim();
+        if (this.#cache.lastLabelsValue != labelValue) {
+            this.#cache.lastLabelsValue = labelValue;
+            this.parseLabelValues(labelValue);
+        }
+        if (this.hasLabels) {
+            this.labelsPlace = dr.label_place;
+            this.labelsAlign = dr.label_align;
+            this.labelsRotate = dr.label_rotate;
+            this.labelsPadding = dr.label_padding;
+            this.labelsFont = dr.label_font?.trim();
+            this.labelsSpacing = dr.label_spacing?.trim();
+            this.labelsColor = dr.label_color;
+        }
+        return this.#cache.isNull;
+    }
+
+    /** Label values can be specified as a numeric range and count (eg. "0-360 / 4")
+        or as a CSV series of strings (eg. "N, E, S, W"). The string is evaluated before parsing,
+        so embedded JS (in ${...} blocks) can be executed, for example to generate a dynamic array of formatted values. */
+    protected parseLabelValues(value: string) {
+        if (!value) {
+            this.labels = [];
+            return;
+        }
+        value = evaluateStringValue(value);
+        if (value.includes(',')) {
+            this.labels = value.split(/\s*,\s*/);
+            return;
+        }
+
+        const rngCnt = value.split(/\s*\/\s*/, 2),
+            cnt = parseFloat(rngCnt[1]) || 2;
+        let [from, to]: any = rngCnt[0].split(/\s*-\s*/, 2);
+        from = parseFloat(from) || 0;
+        to = parseFloat(to) || 0;
+        if (from == to || cnt < 2)  {
+            this.labels = [];
+            return;
+        }
+        const n = (to - from) / (cnt - 1),
+            a: string[] = [];
+        for (let i=0; i < cnt; from += n, ++i)
+            a.push(from.toString())
+        this.labels = a;
+        // console.log(value, from, to, cnt)
+    }
+
+    // Subclasses must implement these methods.
+    protected abstract generateTicksPath(tick: TickProperties, metrics: TickMetrics): void;
+    protected abstract generateLabelsPath(ctx: RenderContext2D, metrics: LabelMetrics): void;
+
+    protected generateTicksType(tick:TickProperties, m: PathMetrics) {
+        let len: any = tick.len.value
+        if (tick.len.isRelative)
+            len *= m.lenScl;
+        if (tick.place == Placement.Inside)
+            len *= -1;
+        // minor ticks count is also based on major tick count
+        let ticksCount = this.majTicksCount;
+        if (tick.type == 1) {
+            // minor ticks, adjust count and length type
+            ticksCount += (ticksCount - 1) * tick.count;
+            // create array of tick lengths so that each major tick place is skipped (zero length)
+            len = [0, ...Array.from({length: tick.count}, () => len)];
+        }
+
+        // call subclass implementation to generate actual path
+        this.generateTicksPath(tick, { ...m, ticksCount, tickLen: len })
+    }
+
+    protected generateTicks(m: PathMetrics) {
+        if (this.majTicksCount)
+            this.generateTicksType(this.majTicks, m);
+        else
+            this.majTicksPath = null;
+        if (this.minTicksCount)
+            this.generateTicksType(this.minTicks, m);
+        else
+            this.minTicksPath = null;
+    }
+
+    protected generateLabels(ctx: RenderContext2D, m: PathMetrics) {
+        if (!this.hasLabels) {
+            this.labelsPath = null;
+            return;
+        }
+
+        // calculate label offset based on longest tick length pointing in same direction
+        const position = this.#labels.place == Placement.Inside ? -1 : 1;
+        let offset = 0;
+        for (const tick of this.#ticks) {
+            let len = 0;
+            if (tick.place == Placement.Center)
+                len = tick.len.value * (tick.len.isRelative ? m.lenScl : 1) * .5;
+            else if (tick.place == this.#labels.place)
+                len = tick.len.value * (tick.len.isRelative ? m.lenScl : 1);
+            else
+                continue;
+            if (len > offset)
+                offset = len;
+        }
+        // add a fixed default offset, but scale it down if needed
+        offset += Math.min(8, 8 * m.lenScl);
+        // extra user-specified padding around label;
+        offset += this.#labels.padding * m.lenScl;
+        // reverse offset if placing labels inside the curve or at top/left
+        offset *= position;
+
+        // set up canvas typography options to be used when generating text paths
+        ctx.textWrap = true;
+        ctx.fontHinting = true;
+        ctx.fontVariant = StyledText.defaultFontVariant as any;
+        ctx.font = this.#labels.font;
+        if (this.#labels.spacing.value)
+            ctx.letterSpacing = this.#labels.spacing.toString();
+        if (this.labelsAlign != Alignment.NONE)
+            ctx.textAlign = ALIGNMENT_ENUM_NAMES[this.labelsAlign & Alignment.H_MASK];
+
+        // call subclass implementation to generate actual path
+        this.generateLabelsPath(ctx, {...m, offset, position });
+    }
+
+    protected metrics(rect: Rectangle) {
+        const w = this.width.isRelative ? this.width.value * .01 * rect.width : this.width.value,
+            h = this.height.isRelative ? this.height.value * .01 * rect.height : this.height.value,
+            rX = w * .5,
+            rY = h * .5,
+            cX = this.width.isRelative ? rX : rect.center.x,
+            cY = this.height.isRelative ? rY : rect.center.y,
+            lenScl = Math.min(w, h) * .01;
+        return { w, h, rX, rY, cX, cY, lenScl }
+    }
+
+    protected generatePaths(ctx: RenderContext2D, rect: Rectangle) {
+        const m = this.metrics(rect);
+        // Re-geneate or clear paths as needed
+        this.generateTicks(m);
+        this.generateLabels(ctx, m);
+
+        // Calculate scaling factor if needed to keep combination of all paths within specified dimensions.
+        const majB = Rectangle.fromBounds(this.majTicksPath?.bounds),
+            minB = Rectangle.fromBounds(this.minTicksPath?.bounds),
+            lblB = Rectangle.fromBounds(this.labelsPath?.bounds),
+            b = Rectangle.united(majB, minB, lblB),
+            w = this.width.isRelative ? this.width.value * .01 * rect.width : b.width,
+            h = this.height.isRelative ? this.height.value * .01 * rect.height : b.height,
+            scale = Math.min(1, w / b.width, h / b.height);
+        // console.log(rect, b, w, h, scale)
+        b.scale(scale);
+
+        // Calculate offset to match alignment settings.
+        // When we have both ticks and labels with a center/middle alignment we actually want to calculate
+        // the offset w/out the labels. This will propertly align the tick marks w/out offsetting for extra
+        // "overhang" caused by labels. Otherwise the tick scale may unexpectedly appear off-center/middle.
+        if (!!this.majTicksPath && !!this.labelsPath && (this.alignment & Alignment.CENTER)) {
+            const oB = Rectangle.united(majB, minB).scale(scale);
+            // Add back respective overall bounds, with labels, for off-center alignments
+            if (!(this.alignment & Alignment.HCENTER))
+                oB.unite(new Rectangle(b.left, 0, b.width, 0));
+            if (!(this.alignment & Alignment.VCENTER))
+                oB.unite(new Rectangle(0, b.top, 0, b.height));
+            // console.log(`${b}\n${oB}\n`, lB);
+            b.setOrigin(super.computeOffset(oB, rect, true));
+        }
+        else {
+            // If there's only ticks _or_ labels, or both alignment values are at the edges,
+            // then just offset based on overall bounds, which will make sure no parts are drawn off-canvas.
+            b.setOrigin(super.computeOffset(b, rect, true));
+        }
+        return { bounds: b, scale };
+    }
+
+    // IRenderable
+    /** Draws the gauge marks with all styling and positioning options applied onto `ctx` using `rect` dimensions for scaling and alignment. */
+    render(ctx: RenderContext2D, rect: Rectangle): void {
+        if (this.isEmpty)
+            return;
+
+        if (this.#cache.isDirty(rect)) {
+            const {bounds, scale} = this.generatePaths(ctx, rect);
+            // cache the calculated bounds and offset
+            this.#cache.bounds.set(bounds);
+            this.#cache.scale = scale;
+            this.#cache.rect.set(rect);
+        }
+
+        ctx.save();
+        ctx.translate(this.#cache.bounds.x, this.#cache.bounds.y);
+        ctx.scale(this.#cache.scale, this.#cache.scale);
+
+        if (this.majTicksPath) {
+            this.majTicksStroke.render(ctx, rect);
+            ctx.stroke(this.majTicksPath);
+        }
+        if (this.minTicksPath) {
+            this.minTicksStroke.render(ctx, rect);
+            ctx.stroke(this.minTicksPath);
+        }
+        if (this.labelsPath) {
+            this.#labels.fill.render(ctx, true);
+            ctx.fill(this.labelsPath);
+        }
+        ctx.restore();
+
+     }
+
+}

--- a/src/modules/elements/GaugeTicks.ts
+++ b/src/modules/elements/GaugeTicks.ts
@@ -1,9 +1,10 @@
 import { Alignment, ColorUpdateType, LayerRole, ParseState, Path2D, Placement, Rectangle, UnitValue } from '../';
-import { arraysMatchExactly, assignExistingProperties, evaluateStringValue, evaluateValue, parseAlignmentFromValue, parsePlacement } from '../../utils';
+import { arraysMatchExactly, evaluateStringValue, evaluateValue, parseAlignmentFromValue, parseBoolFromValue, parsePlacement } from '../../utils';
 import { ALIGNMENT_ENUM_NAMES, Str } from '../../utils/consts';
 import { BrushStyle, StrokeStyle, StyledText } from './';
-import SizedElement from './SizedElement';  // must be direct import for subclass
-import type { RenderContext2D, TpActionDataRecord,  } from '../';
+import SizedElement, {type  SizedElementInit} from './SizedElement';  // must be direct import for subclass
+
+export type GaugeTicksInit = SizedElementInit & PartialDeep<GaugeTicks>;
 
 export type TickProperties = {
     type: 0|1
@@ -49,14 +50,15 @@ export default abstract class GaugeTicks extends SizedElement
         path: <Path2D | null> null,  // generated Path2D for the labels, if any
     };
 
-    constructor(init?: PartialDeep<GaugeTicks>) {
+    /** The constructor doesn't call `super.init(init)`, subclasses should do that. */
+    protected constructor(init?: GaugeTicksInit) {
         super();
         this.#ticks = [
             this.#initTickRecord(0, init?.majTicksStroke),
             this.#initTickRecord(1, init?.minTicksStroke),
         ];
         this.#labels.fill = new BrushStyle(init?.labelsStyle);
-        assignExistingProperties(this, init, 0);
+        // super.init(init);
     }
 
     #initTickRecord(type: 0|1, strokeInit?: PartialDeep<StrokeStyle>): TickProperties {

--- a/src/modules/elements/LinearProgressBar.ts
+++ b/src/modules/elements/LinearProgressBar.ts
@@ -37,7 +37,7 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
         the long edges of the bar, and `height` sets the padding around the endpoints (short edges). */
     padding: SizeType = new Size();
 
-    constructor(init?: Partial<LinearProgressBar>) {
+    constructor(init?: PartialDeep<LinearProgressBar>) {
         super();
         this.valueStyle = new DrawingStyle(init?.valueStyle);
         assignExistingProperties(this, init, 1);

--- a/src/modules/elements/LinearProgressBar.ts
+++ b/src/modules/elements/LinearProgressBar.ts
@@ -142,7 +142,7 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
         dirty = this.style.loadFromDataRecord(ParseState.splitRecordKeys(dr, 'ctr_' + Act.IconStyle + Str.IdSep)) || dirty;
         // console.dir(this);
         if (dirty)
-            this.clearCahe();
+            this.clearCache();
         return this;
     }
 
@@ -166,7 +166,7 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
         if (this.width.value != newSize.width || this.height.value != newSize.height) {
             this.width.value = newSize.width;
             this.height.value = newSize.height;
-            this.clearCahe();
+            this.clearCache();
         }
 
         // Draw the container area using parent class.

--- a/src/modules/elements/LinearProgressBar.ts
+++ b/src/modules/elements/LinearProgressBar.ts
@@ -1,13 +1,14 @@
 
-import { LayerRole, Orientation, ParseState, Path2D, Size, UnitValue, ColorUpdateType } from '../';
-import { assignExistingProperties, clamp, evaluateValue, round3p } from '../../utils'
+import { ColorUpdateType, LayerRole, Orientation, ParseState, Path2D, Size, UnitValue, } from '../';
+import { clamp, evaluateValue, round3p } from '../../utils'
 import { Act, Str } from '../../utils/consts'
 import { DrawingStyle } from './';
-import StyledRectangle from './StyledRectangle';
+import StyledRectangle, { type StyledRectangleInit } from './StyledRectangle';
 import type { IColorElement, ILayerElement, IValuedElement } from '../interfaces';
-import type { Rectangle, RenderContext2D, SizeType } from '../';
+import type { Rectangle, } from '../';
 
-const enum DrawDirection {
+/** Progress bar incremental direction. */
+export const enum DrawDirection {
     /** Left to right or bottom to top. */
     Normal,
     /** Right to left or top to bottom. */
@@ -37,10 +38,10 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
         the long edges of the bar, and `height` sets the padding around the endpoints (short edges). */
     padding: SizeType = new Size();
 
-    constructor(init?: PartialDeep<LinearProgressBar>) {
+    constructor(init?: StyledRectangleInit & PartialDeep<LinearProgressBar>) {
         super();
         this.valueStyle = new DrawingStyle(init?.valueStyle);
-        assignExistingProperties(this, init, 1);
+        super.init(init);
     }
 
     // ILayerElement

--- a/src/modules/elements/LinearProgressBar.ts
+++ b/src/modules/elements/LinearProgressBar.ts
@@ -1,34 +1,58 @@
 
-import { IColorElement, ILayerElement, IValuedElement } from '../interfaces';
-import { Orientation, ParseState, Path2D, Rectangle, RenderContext2D, SizeType, Size, UnitValue, ColorUpdateType } from '../';
-import { arraysMatchExactly, evaluateValue, round3p } from '../../utils'
+import { LayerRole, Orientation, ParseState, Path2D, Size, UnitValue, ColorUpdateType } from '../';
+import { assignExistingProperties, clamp, evaluateValue, round3p } from '../../utils'
+import { Act, Str } from '../../utils/consts'
 import { DrawingStyle } from './';
 import StyledRectangle from './StyledRectangle';
+import type { IColorElement, ILayerElement, IValuedElement } from '../interfaces';
+import type { Rectangle, RenderContext2D, SizeType } from '../';
 
-const enum DrawDirection { Normal, Reverse, Center };
+const enum DrawDirection {
+    /** Left to right or bottom to top. */
+    Normal,
+    /** Right to left or top to bottom. */
+    Reverse,
+    /** Draw from center in both directions at the same time. */
+    Center,
+    /** Draw from center with direction depending on current value's sign,
+        towards left/bottom for negative values or to right/top for positive ones. TODO */
+    CenterAuto,
+};
 
-// Draws a rectangle shape on a canvas context with optional radii applied to any/all of the 4 corners (like CSS). The shape can be fully styled with the embedded DrawingStyle property.
+/** A progress bar is essentially two rectangles, one inside the other, with the inner one changing length to represent a percentage value.
+    The outer container and inner value boxes can be fully styled with the embedded `DrawingStyle` properties.
+    This class inherits from `StyledRectangle` which is used for the outer container box, and holds additional properties to control the
+    inner value part.  Any corner radius set on the outer container box will also be applied to the inner value part (after some adjustments for size).
+*/
 export default class LinearProgressBar extends StyledRectangle implements ILayerElement, IValuedElement, IColorElement
 {
     orientation: Orientation = Orientation.H;
     direction: DrawDirection = DrawDirection.Normal;
-    valueStyle: DrawingStyle = new DrawingStyle();
-    value: number = 0;  // % of extents, 0 - 100 range only
-
-    private padding: SizeType = Size.new();  // width = sides, height = endpoints
+    /** Styling properties for the inner value part of the progress bar. The outer container is styled by the parent's {@link StyledRectangle#style} property. */
+    valueStyle: DrawingStyle;
+    /** Progress bar value in percent, 0-100. */
+    value: number = 0;
+    /** Padding controls how much space to leave around the outside of the progress bar relative to the total drawing area.
+        It determines the final size of the progress bar based on orientation. With `width` value determines padding along
+        the long edges of the bar, and `height` sets the padding around the endpoints (short edges). */
+    padding: SizeType = new Size();
 
     constructor(init?: Partial<LinearProgressBar>) {
         super();
-        Object.assign(this, init);
+        this.valueStyle = new DrawingStyle(init?.valueStyle);
+        assignExistingProperties(this, init, 1);
     }
 
     // ILayerElement
-    readonly type: string = "LinearProgressBar";
+    /** @internal */
+    readonly layerRole: LayerRole = LayerRole.Drawable;
 
     // IValuedElement
-    setValue(value: string) { this.value = Math.min(Math.max(evaluateValue(value), 0), 100); }
+    /** Sets current {@link LinearProgressBar#value} property using an evaluated string. */
+    setValue(value: string) { this.value = clamp(evaluateValue(value), 0, 100); }
 
     // IColorElement
+    /** @internal */
     setColor(value: string, type: ColorUpdateType): void {
         if (type & ColorUpdateType.Foreground)
             this.valueStyle.setColor(value, ColorUpdateType.Fill);
@@ -41,22 +65,18 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
         return super.isEmpty && this.valueStyle.isEmpty;
     }
 
-    loadFromActionData(state: ParseState): LinearProgressBar
-    {
-        let atEnd = false,
-            ctrStyleParsed = false,
-            valStyleParsed = false,
-            dirty = false;
-        for (const e = state.data.length; state.pos < e && !atEnd; ) {
-            const data = state.data[state.pos];
-            const dataType = data?.id.split('pbar_').at(-1);  // last part of the data ID determines its meaning
-            switch (dataType)
+    /** @internal */
+    loadFromActionData(state: ParseState): LinearProgressBar {
+        const dr = state.asRecord(state.pos, "pbar_");
+        let dirty = false;
+        for (const [key, value] of Object.entries(dr)) {
+            switch (key)
             {
                 case 'dir':
                     // defaults
                     this.orientation = Orientation.H;  // horizontal
                     this.direction = DrawDirection.Normal;    // LR/BT/CTR
-                    switch (data.value.charAt(0)) {
+                    switch (value.charAt(0)) {
                         case '⬅':
                             this.direction = DrawDirection.Reverse;
                             break;
@@ -82,64 +102,47 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
                 // note that these size properties are not used the same way as the parent's size --
                 // here they control padding, and the parent's actual size is set at render time.
                 case 'size_w': {
-                    const sz = evaluateValue(data.value);
+                    const sz = evaluateValue(value);
                     if (sz > 0)
                         this.padding.width = sz * 2;
                     break;
                 }
                 case 'size_w_unit':
-                    this.width.setUnit(data.value);
+                    this.width.setUnit(value);
                     break;
-
                 case 'size_h': {
-                    const sz = evaluateValue(data.value);
+                    const sz = evaluateValue(value);
                     if (sz > 0)
                         this.padding.height = sz * 2;
                     break;
                 }
                 case 'size_h_unit':
-                    this.height.setUnit(data.value);
+                    this.height.setUnit(value);
                     break;
-
                 case 'radius':
-                    dirty = super.parseRadius(data.value) || dirty;
+                    dirty = super.parseRadius(value) || dirty;
                     break;
                 case 'radius_unit':
-                    if (UnitValue.isRelativeUnit(data.value) != this.radiusIsRelative) {
+                    if (UnitValue.isRelativeUnit(value) != this.radiusIsRelative) {
                         this.radiusIsRelative = !this.radiusIsRelative;
                         dirty = true;
                     }
                     break;
-
                 case 'value':
-                    this.setValue(data.value);
+                    this.setValue(value);
                     break;
 
                 default:
-                    if (!ctrStyleParsed && dataType?.startsWith('ctr_')) {
-                        // Check for shadow and line style changes which may affect cached path.
-                        const sarry = this.adjustSizeForShadow ? [this.style.shadow.blur, this.style.shadow.offset.x, this.style.shadow.offset.y] : null;
-                        const lw = this.style.line.width;
-                        this.style.loadFromActionData(state, 'ctr_');
-                        dirty = dirty || (lw.value != this.style.line.width.value ||
-                                lw.isRelative != this.style.line.width.isRelative ||
-                                (sarry! && !arraysMatchExactly(sarry, [this.style.shadow.blur, this.style.shadow.offset.x, this.style.shadow.offset.y])))
-                        ctrStyleParsed = true;
-                    }
-                    else if (!valStyleParsed && dataType?.startsWith('val_')) {
-                        this.valueStyle.loadFromActionData(state, 'val_');
-                        valStyleParsed = true;
-                    }
-                    else {
-                        atEnd = true;
-                    }
                     continue;
             }
-            ++state.pos;
+            delete dr[key];  // remove handled property for quicker downstream operation
         }
+        this.valueStyle.loadFromDataRecord(ParseState.splitRecordKeys(dr, 'val_' + Act.IconStyle + Str.IdSep, true));
+        // check shadow dimensions and line width for changes
+        dirty = this.style.loadFromDataRecord(ParseState.splitRecordKeys(dr, 'ctr_' + Act.IconStyle + Str.IdSep)) || dirty;
+        // console.dir(this);
         if (dirty)
-            this.cache.clear();
-        //console.dir(this);
+            this.clearCahe();
         return this;
     }
 
@@ -163,7 +166,7 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
         if (this.width.value != newSize.width || this.height.value != newSize.height) {
             this.width.value = newSize.width;
             this.height.value = newSize.height;
-            this.cache.clear();
+            this.clearCahe();
         }
 
         // Draw the container area using parent class.
@@ -179,11 +182,11 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
         const ctrRect = window.clone();
 
         let penW: number = 0;
-        if (!this.valueStyle.line.isEmpty) {
+        if (!this.valueStyle.stroke.isEmpty) {
             // adjust for pen size
-            if (this.valueStyle.line.width.isRelative)
-                this.valueStyle.line.widthScale = Math.min(window.width, window.height) * .005 /* penScale */;
-            penW = this.valueStyle.line.scaledWidth;
+            if (this.valueStyle.stroke.width.isRelative)
+                this.valueStyle.stroke.widthScale = Math.min(window.width, window.height) * .005 /* penScale */;
+            penW = this.valueStyle.stroke.scaledWidth;
             window.adjust(round3p(penW * .5), -penW);
         }
         // set value part length (width/height) and offset position for drawing
@@ -214,8 +217,8 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
         if (this.haveRadius) {
             // if the container has a border then expand the value drawing area by a portion of it, or at least one pixel,
             // to slightly overlap the content area... looks better this way because the radii will never quite match up perfectly.
-            if (penW && !this.valueStyle.line.pen.isEmpty) {
-                const ctrPenW = this.style.line.scaledWidth,
+            if (penW && !this.valueStyle.stroke.isEmpty) {
+                const ctrPenW = this.style.stroke.scaledWidth,
                     d = Math.max(round3p(ctrPenW * .2), .5);
                 window.adjust(-d, d * 2);
                 penW += ctrPenW;  // we use this below to scale the radius
@@ -231,8 +234,7 @@ export default class LinearProgressBar extends StyledRectangle implements ILayer
                 ratio = Math.max((window.height - penW * 4) / ctrRect.height, 0);
             else
                 ratio = Math.max((window.width - penW * 4) / ctrRect.width, 0);
-            const radii = this.radii.map(r => round3p(r * ratio));
-            path.roundRect(window.x, window.y, window.width, window.height, radii);
+            path.roundRect(window.x, window.y, window.width, window.height, this.scaledRadii(ratio));
         }
         // no radius
         else {

--- a/src/modules/elements/LinearTicks.ts
+++ b/src/modules/elements/LinearTicks.ts
@@ -1,0 +1,61 @@
+import { Alignment, Orientation, ParseState, Placement, } from '../';
+import { assignExistingProperties, linearGaugeTicksPath, linearLabelsPath } from '../../utils';
+import { Act, Str } from '../../utils/consts';
+import GaugeTicks, { type LabelMetrics, type TickMetrics, type TickProperties } from './GaugeTicks';  // must be direct import for subclass
+import type { IColorElement, ILayerElement, IRenderable } from '../interfaces';
+import type { RenderContext2D, /* TpActionDataRecord */ } from '../';
+
+/** Implementation of `GaugeTicks` for drawing ticks/labels along a linear path, either horizontally or vertically. */
+export default class LinearTicks extends GaugeTicks implements ILayerElement, IRenderable, IColorElement
+{
+    #orientation: Orientation = Orientation.H;
+
+    constructor(init?: PartialDeep<LinearTicks>) {
+        super(init);
+        assignExistingProperties(this, init, 0);
+        // Linear marks only use the width property, as total length, and height is always 100% for path generation purposes.
+        this.height.value = 100;
+        this.height.unit = '%';
+    }
+
+    /** Tick path orientation. Ticks are drawn perpendicular to this path. */
+    get orientation():Orientation { return this.#orientation; }
+    set orientation(v: Orientation | string) {
+        if (v == undefined)
+            return;
+        if (typeof v == 'string')
+            v = v[0]?.toUpperCase() == 'V' ? Orientation.V : Orientation.H;
+        if (this.#orientation != v) {
+            this.#orientation = v;
+            this.clearCache();
+        }
+    }
+
+    /** @internal */
+    loadFromActionData(state: ParseState): LinearTicks {
+        const dr = state.asRecord(state.pos, Act.IconLinearTicks + Str.IdSep);
+        super.loadFromDataRecord(dr);
+        this.orientation = dr.orientation;
+        return this;
+    }
+
+    protected override generateTicksPath(tick: TickProperties, m: TickMetrics) {
+        tick.path = linearGaugeTicksPath(
+            0, 0, m.w, this.orientation == Orientation.V,
+            m.ticksCount, m.tickLen, tick.place == Placement.Center
+        );
+        // console.log("TICKS PATH:", idx, m.cX, m.cY, m.rX, m.rY, tick.count, m.n, len, tick.path.bounds);
+    }
+
+    protected override generateLabelsPath(ctx: RenderContext2D, m: LabelMetrics) {
+        const x = this.orientation == Orientation.H ? 0 : m.offset,
+              y = this.orientation == Orientation.V ? 0 : m.offset;
+        this.labelsPath = linearLabelsPath(ctx,
+            x, y, m.w, this.orientation == Orientation.V,
+            this.labels, m.position, this.labelsRotate,
+            this.labelsAlign == Alignment.NONE
+        );
+        // console.log("LABELS PATH:", this.labels, m, this.labelsPath.bounds);
+    }
+
+}

--- a/src/modules/elements/LinearTicks.ts
+++ b/src/modules/elements/LinearTicks.ts
@@ -1,18 +1,19 @@
 import { Alignment, Orientation, ParseState, Placement, } from '../';
-import { assignExistingProperties, linearGaugeTicksPath, linearLabelsPath } from '../../utils';
+import { linearGaugeTicksPath, linearLabelsPath } from '../../utils';
 import { Act, Str } from '../../utils/consts';
-import GaugeTicks, { type LabelMetrics, type TickMetrics, type TickProperties } from './GaugeTicks';  // must be direct import for subclass
+import GaugeTicks, { type GaugeTicksInit, type LabelMetrics, type TickMetrics, type TickProperties } from './GaugeTicks';  // must be direct import for subclass
 import type { IColorElement, ILayerElement, IRenderable } from '../interfaces';
-import type { RenderContext2D, /* TpActionDataRecord */ } from '../';
+
+export type LinearTicksInit = GaugeTicksInit & PartialDeep<LinearTicks>;
 
 /** Implementation of `GaugeTicks` for drawing ticks/labels along a linear path, either horizontally or vertically. */
 export default class LinearTicks extends GaugeTicks implements ILayerElement, IRenderable, IColorElement
 {
     #orientation: Orientation = Orientation.H;
 
-    constructor(init?: PartialDeep<LinearTicks>) {
+    constructor(init?: LinearTicksInit) {
         super(init);
-        assignExistingProperties(this, init, 0);
+        super.init(init);
         // Linear marks only use the width property, as total length, and height is always 100% for path generation purposes.
         this.height.value = 100;
         this.height.unit = '%';

--- a/src/modules/elements/Path.ts
+++ b/src/modules/elements/Path.ts
@@ -1,7 +1,7 @@
-import { LayerRole, Path2D, PathBoolOperation, Size, TpActionDataRecord } from '..';
-import { assignExistingProperties } from '../../utils';
+import { LayerRole, PathBoolOperation } from '..';
 import { PATH_BOOL_OPERATION_CHOICES } from '../../utils/consts';
-import SizedElement from './SizedElement'
+import SizedElement, {type  SizedElementInit} from './SizedElement'
+import type { Size, Path2D } from '..';
 
 export class PathCache {
     path: Path2D | null = null;
@@ -15,6 +15,8 @@ export class PathCache {
     }
 }
 
+export type PathInit = SizedElementInit & PartialDeep<Path>;
+
 /** Base class for Path elements. Extends {@link SizedElement} with {@link operation} property and provides helper methods. */
 export default class Path extends SizedElement
 {
@@ -27,9 +29,9 @@ export default class Path extends SizedElement
 
     readonly layerRole: LayerRole = LayerRole.PathProducer;
 
-    constructor(init?: PartialDeep<Path>) {
+    protected constructor(init?: PathInit) {
         super();
-        assignExistingProperties(this, init, 1);
+        super.init(init);
     }
 
     /** Clears the generated & cached Path2D object (if any). Some `Path` subclasses my not use the cache.

--- a/src/modules/elements/Path.ts
+++ b/src/modules/elements/Path.ts
@@ -34,7 +34,7 @@ export default class Path extends SizedElement
 
     /** Clears the generated & cached Path2D object (if any). Some `Path` subclasses my not use the cache.
         Typically the cache management is handled automatically when relevant properties are modified. */
-    clearCahe() {
+    clearCache() {
         this.cache.clear();
     }
 

--- a/src/modules/elements/Path.ts
+++ b/src/modules/elements/Path.ts
@@ -15,17 +15,27 @@ export class PathCache {
     }
 }
 
-/** Base class for Path elements. Extends SizedElement with `operation` property and provides helper methods. */
+/** Base class for Path elements. Extends {@link SizedElement} with {@link operation} property and provides helper methods. */
 export default class Path extends SizedElement
 {
-    operation: PathBoolOperation = PathBoolOperation.None;  // boolean operation to perform with previous path, if any
+    /** Boolean operation to perform with previous path, if any.
+        May be used by subclasses in their `IPathProducer#getPath` method to automatically combine with other paths. */
+    operation: PathBoolOperation = PathBoolOperation.None;
+    /** Cache for generated `Path3D` objects, possibly scaled to a particular size. May be used by subclasses.
+        @see {@link clearCache}. */
     protected readonly cache: PathCache = new PathCache();
 
     readonly layerRole: LayerRole = LayerRole.PathProducer;
 
-    constructor(init?: Partial<Path> | any) {
-        super(init);
-        assignExistingProperties(this, init, 0);
+    constructor(init?: Partial<Path>) {
+        super();
+        assignExistingProperties(this, init, 1);
+    }
+
+    /** Clears the generated & cached Path2D object (if any). Some `Path` subclasses my not use the cache.
+        Typically the cache management is handled automatically when relevant properties are modified. */
+    clearCahe() {
+        this.cache.clear();
     }
 
     /** Parses a string value into an `PathBoolOperation` enum type result and returns it, or PathBoolOperation.None if the value wasn't valid. */
@@ -37,7 +47,7 @@ export default class Path extends SizedElement
         return ret;
     }
 
-    /** Returns true if any properties were changed. */
+    /** @internal  Returns true if any parent `SizedElement` properties were changed. */
     protected loadFromDataRecord(dr: TpActionDataRecord): boolean
     {
         if (dr.operation) {

--- a/src/modules/elements/Path.ts
+++ b/src/modules/elements/Path.ts
@@ -27,7 +27,7 @@ export default class Path extends SizedElement
 
     readonly layerRole: LayerRole = LayerRole.PathProducer;
 
-    constructor(init?: Partial<Path>) {
+    constructor(init?: PartialDeep<Path>) {
         super();
         assignExistingProperties(this, init, 1);
     }

--- a/src/modules/elements/RectanglePath.ts
+++ b/src/modules/elements/RectanglePath.ts
@@ -1,10 +1,11 @@
 
 import { IPathProducer } from '../interfaces';
 import { ParseState, Path2D, Point, Rectangle, UnitValue } from '../';
-import { assignExistingProperties, parseNumericArrayString } from '../../utils';
+import { parseNumericArrayString } from '../../utils';
 import { Act, Str } from '../../utils/consts'
-import Path from './Path';
-import type { PointType, TpActionDataRecord } from '../';
+import Path, { type PathInit } from './Path';
+
+export type RectanglePathInit = PathInit & PartialDeep<RectanglePath>;
 
 /** Creates a rectangle path with optional radii applied to any/all of the 4 corners (like CSS). */
 export default class RectanglePath extends Path implements IPathProducer
@@ -16,9 +17,9 @@ export default class RectanglePath extends Path implements IPathProducer
     protected haveRadius: boolean = false;
     #radii: Array<PointType> = [];
 
-    constructor(init?: PartialDeep<RectanglePath>) {
+    constructor(init?: RectanglePathInit) {
         super();
-        assignExistingProperties(this, init, 1);
+        super.init(init);
     }
 
     /** Validates the value types in given array and that none of the values are `< 0`;

--- a/src/modules/elements/RectanglePath.ts
+++ b/src/modules/elements/RectanglePath.ts
@@ -16,7 +16,7 @@ export default class RectanglePath extends Path implements IPathProducer
     protected haveRadius: boolean = false;
     #radii: Array<PointType> = [];
 
-    constructor(init?: Partial<RectanglePath>) {
+    constructor(init?: PartialDeep<RectanglePath>) {
         super();
         assignExistingProperties(this, init, 1);
     }

--- a/src/modules/elements/RectanglePath.ts
+++ b/src/modules/elements/RectanglePath.ts
@@ -61,7 +61,7 @@ export default class RectanglePath extends Path implements IPathProducer
         if (!this.compareRadii(radii)) {
             this.#radii = radii;
             this.haveRadius = radii.some((v) => v.x > 0 || v.y > 0);
-            this.clearCahe();
+            this.clearCache();
         }
     }
 
@@ -96,7 +96,7 @@ export default class RectanglePath extends Path implements IPathProducer
             dirty = true;
         }
         if (dirty)
-            this.clearCahe();
+            this.clearCache();
         // console.dir(this);
         return dirty;
     }

--- a/src/modules/elements/RectanglePath.ts
+++ b/src/modules/elements/RectanglePath.ts
@@ -1,62 +1,120 @@
 
 import { IPathProducer } from '../interfaces';
-import { ParseState, Path2D, Rectangle, UnitValue } from '../';
-import { arraysMatchExactly, parseNumericArrayString, round3p } from '../../utils';
+import { ParseState, Path2D, Point, Rectangle, UnitValue } from '../';
+import { assignExistingProperties, parseNumericArrayString } from '../../utils';
 import { Act, Str } from '../../utils/consts'
 import Path from './Path';
+import type { PointType, TpActionDataRecord } from '../';
 
 /** Creates a rectangle path with optional radii applied to any/all of the 4 corners (like CSS). */
 export default class RectanglePath extends Path implements IPathProducer
 {
-    /** `radii` value is like css border-radius, 1-4 numbers starting at top left corner, etc; empty array for no radius;
-        individual values can be in either percent of overall size (like CSS border-radius %) or in absolute pixels.
-        See `radii` param at https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect#syntax  */
-    radii: number[] = [];
+    /** `true` if radius values in `radii` array are given in percentages, or `false` if they represent absolute pixels. Default is `true`. */
     radiusIsRelative: boolean = true;
 
+    /** This property indicates if any positive radius values have been set. Can be used to determine if a faster `rect()` can be drawn instead of `roundRect()`. */
     protected haveRadius: boolean = false;
+    #radii: Array<PointType> = [];
 
-    // constructor(init?: Partial<RectanglePath> | any) { super(init); assignExistingProperties(this, init, 0); }
+    constructor(init?: Partial<RectanglePath>) {
+        super();
+        assignExistingProperties(this, init, 1);
+    }
 
-    // ILayerElement
-    readonly type: string = "RectanglePath";
+    /** Validates the value types in given array and that none of the values are `< 0`;
+        Turns all single numeric values into `{x,y}` PointType objects. **Modifies the input array** if needed.
+        Any array members which are neither numeric nor `{x,y}` objects are replaced with a zero value. */
+    static cleanRadiusArray(radii: Array<PointType|number>): asserts radii is Array<PointType> {
+        if (radii.length > 4)
+            radii.length = 4;
+        radii.forEach((v:any, i, a) => {
+            if (typeof v == 'number') {
+                a[i] = Point.new(Math.max(0, v));
+            }
+            else if (Number.isFinite(v.x) && Number.isFinite(v.y)) {
+                if (v.y < 0) v.y = 0;
+                if (v.x < 0) v.x = 0;
+            }
+            else {
+                a[i] = Point.new();
+            }
+        });
+    }
 
     /** Returns true if the rectangle is empty (width or height are zero) */
     get isEmpty(): boolean {
         return !this.width.value || !this.height.value;
     }
 
-    // returns true if radius array value has changed from saved version
+    /** `radii` value is like css border-radius, an array of 1-4 "point-like" objects (`{x,y}`) starting at top left corner, etc.
+        Empty array for no radius. Values can be in either percent of overall size (like CSS border-radius %) or in absolute pixels,
+        depending on the {@link radiusIsRelative} property. Radius values cannot be negative.
+
+        See `radii` param at https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect#syntax
+    */
+    get radii(): Array<PointType> { return this.#radii; }
+    /** The radii can be set using an array of 1-4 numbers or `PointType` `{x,y}` objects, or a single numeric value (for all 4 corners). */
+    set radii(radii: Array<number|PointType> | number) {
+        if (typeof radii == 'number')
+            radii = [radii];
+        RectanglePath.cleanRadiusArray(radii);
+        if (!this.compareRadii(radii)) {
+            this.#radii = radii;
+            this.haveRadius = radii.some((v) => v.x > 0 || v.y > 0);
+            this.clearCahe();
+        }
+    }
+
+    /** Returns `true` if `radii` argument array equals current `radii` property. */
+    protected compareRadii(radii: Array<PointType>) {
+        return (radii.length == this.#radii.length && !radii.some((v, i) => !Point.equals(v, this.#radii[i])))
+    }
+
+    /** Parses string value to radii array and returns `true` if radius array has changed from saved version. */
     protected parseRadius(value: string) {
         const radii = [];
         this.haveRadius = parseNumericArrayString(value, radii, 4, 0);
-        if (!arraysMatchExactly(this.radii, radii)) {
-            this.radii = radii;
+        RectanglePath.cleanRadiusArray(radii);
+        if (!this.compareRadii(radii)) {
+            this.#radii = radii;
             return true;
         }
         return false;
     }
 
-    loadFromActionData(state: ParseState, statePrefix: string = Act.IconRectPath): RectanglePath {
-        const dr = state.asRecord(state.pos, statePrefix + Str.IdSep);
+    /** @internal  Returns true if any properties were changed. */
+    loadFromDataRecord(dr: TpActionDataRecord): boolean | any
+    {
         let dirty = super.loadFromDataRecord(dr);
         if (dr.radius) {
             dirty = this.parseRadius(dr.radius) || dirty;
             delete dr.radius;
         }
-
         if (dr.radius_unit && UnitValue.isRelativeUnit(dr.radius_unit) != this.radiusIsRelative) {
             this.radiusIsRelative = !this.radiusIsRelative;
             delete dr.radius_unit;
             dirty = true;
         }
         if (dirty)
-            this.cache.clear();
+            this.clearCahe();
         // console.dir(this);
+        return dirty;
+    }
+
+    /** @internal */
+    loadFromActionData(state: ParseState, statePrefix: string = Act.IconRectPath): RectanglePath {
+        this.loadFromDataRecord(state.asRecord(state.pos, statePrefix + Str.IdSep));
         return this;
     }
 
+    /** Returns a copy of the current {@link radii} property with each member scaled by `ratio` amount. */
+    scaledRadii(ratio: number): Array<number|PointType> {
+        return this.#radii.map(r => Point.times(r, ratio));
+    }
+
     // IPathProducer
+    /** Returns the rectangle as a `Path2D` object, scaled to fit into `rect` bounds (if size units are relative), and combined
+        with any paths in the `pathStack` according to value of the {@link operation} property. */
     getPath(rect: Rectangle, pathStack?: Array<Path2D>): Path2D
     {
         if (rect.isEmpty)
@@ -69,11 +127,10 @@ export default class RectanglePath extends Path implements IPathProducer
             if (this.haveRadius) {
                 if (this.radiusIsRelative) {
                     const ratio = Math.max((bounds.width + bounds.height) * .005, 0);  // this is a bit simplistic really
-                    const radii = this.radii.map(r => round3p(r * ratio));
-                    this.cache.path.roundRect(bounds.x, bounds.y, bounds.width, bounds.height, radii);
+                    this.cache.path.roundRect(bounds.x, bounds.y, bounds.width, bounds.height, this.scaledRadii(ratio));
                 }
                 else {
-                    this.cache.path.roundRect(bounds.x, bounds.y, bounds.width, bounds.height, this.radii);
+                    this.cache.path.roundRect(bounds.x, bounds.y, bounds.width, bounds.height, this.#radii);
                 }
             }
             else {

--- a/src/modules/elements/RoundProgressGauge.ts
+++ b/src/modules/elements/RoundProgressGauge.ts
@@ -1,32 +1,48 @@
 
-import { ArcDrawDirection, ColorUpdateType } from '../';
+import { ColorUpdateType, ArcDrawDirection, LayerRole, ParseState } from '../';
 import { StrokeStyle, BrushStyle } from './';
-import { clamp, evaluateValue, parseArcDirection } from '../../utils';
+import { assignExistingProperties, evaluateValue, clamp, parseArcDirection } from '../../utils';
 import { M } from '../../utils/consts';
 import type { IColorElement, ILayerElement, IRenderable, IValuedElement } from '../interfaces';
-import type { ParseState, Rectangle, RenderContext2D } from '../';
+import type { Rectangle, RenderContext2D } from '../';
 
-// Draws an arc/circle extending from 0 to 360 degrees based on a given value onto a canvas context.
+/** Draws an arc/circle extending from 0 to 360 degrees based on a given value onto a canvas context. */
 export default class RoundProgressGauge implements ILayerElement, IRenderable, IValuedElement, IColorElement
 {
-    value: number = 0    // decimal percent, -1 through 1
+    /** Gauge value as decimal percent, -1 through 1 */
+    value: number = 0
+    /** A highlight is a copy of the value track with a blur filter applied, drawn behind the value track itself and with the same color. */
     highlightOn = true
-    shadowColor = new BrushStyle('#282828FF')
-    startAngle = 180 * M.D2R  // radians
+    /** Shadow color to draw behind the gauge area. Use any transparent color to disable. */
+    readonly shadowColor = new BrushStyle('#282828FF')
+    /** Starting angle in radians. 0 points east, default is west. */
+    startAngle = 180 * M.D2R
+    /** Drawing direction, clockwise (0), counter-clockwise (1), or automatic (2) based on value being positive (CW) or negative (CCW). */
     direction: ArcDrawDirection = ArcDrawDirection.CW
-    backgroundColor = new BrushStyle('#000000FF')
+    /** The background follows the radius of the gauge, not the full icon drawing area. */
+    readonly backgroundColor = new BrushStyle('#000000FF')
+    /** Radius of gauge arc, expressed as decimal percentage of half of the overall drawing size (eg. radius of 0.5 would be one quarter of the overall image size). */
     radius = 0.39  // approximates the original ratio of 100 for 256px icon size
-    lineStyle: StrokeStyle = new StrokeStyle({
+    /** Style to use for drawing the value track. (The track cannot be filled, only stroked.) */
+    readonly lineStyle: StrokeStyle = new StrokeStyle({
         width: 11.7,   // this line width preserves legacy default size before it was settable
         cap: "round"
     })
 
+    constructor(init?: Partial<RoundProgressGauge>) {
+        assignExistingProperties(this, init, 1);
+    }
+
     // ILayerElement
-    readonly type = "RoundProgressGauge"
+    /** @internal */
+    readonly layerRole: LayerRole = LayerRole.Drawable;
+
     // IValuedElement
+    /** Sets {@link RoundProgressGauge#value} property using an evaluated string. */
     setValue(value: string) { this.value = evaluateValue(value) * .01; }
 
     // IColorElement
+    /** @internal */
     setColor(value: string, type: ColorUpdateType): void {
         switch (type) {
             case ColorUpdateType.Foreground:
@@ -41,69 +57,60 @@ export default class RoundProgressGauge implements ILayerElement, IRenderable, I
         }
     }
 
+    // ILayerElement
+    /** @internal */
     loadFromActionData(state: ParseState): RoundProgressGauge {
-        // the incoming data IDs should be structured with a naming convention
-        let lineParsed = false,
-            atEnd = false,
-            shadowOff = false
-        for (let e = state.data.length; state.pos < e && !atEnd;) {
-            const data = state.data[state.pos]
-            const dataType = data.id.split('gauge_').at(-1);  // last part of the data ID determines its meaning
-            switch (dataType) {
+        const dr = state.asRecord(state.pos, "gauge_");
+        let shadowOff = false;
+        // console.dir(dr);
+        for (const [key, value] of Object.entries(dr)) {
+            switch (key) {
                 case 'color':
-                    this.lineStyle.pen.color = data.value
+                    this.lineStyle.pen.color = value
                     break
                 case 'highlight':
-                    this.highlightOn = (data.value === "On")
+                    this.highlightOn = (value === "On")
                     break
                 case 'start_degree':
-                    this.startAngle = evaluateValue(data.value) * M.D2R
+                    this.startAngle = evaluateValue(value) * M.D2R
                     break
                 case 'value':
-                    this.setValue(data.value)
+                    this.setValue(value)
                     break
                 case 'radius':
-                    this.radius = clamp(evaluateValue(data.value), 2, 200) * .005
+                    this.radius = clamp(evaluateValue(value), 2, 200) * .005
                     break
                 case 'counterclockwise':
-                    this.direction = parseArcDirection(data.value)
+                    this.direction = parseArcDirection(value)
                     break
                 case 'background_color':
-                    this.backgroundColor.color = data.value
+                    this.backgroundColor.color = value
                     break
                 case 'shadow_color':
-                    this.shadowColor.color = data.value
+                    this.shadowColor.color = value
                     break
-
                 // legacy options, keep for BC with <v1.2
                 case 'shadow':
-                    shadowOff = (data.value == "Off")
+                    // force transparent shadow color if using old action with a shadow toggle option
+                    shadowOff = (value == "Off")
                     break
                 case 'cap':
-                    if (!lineParsed)
-                        this.lineStyle.cap = data.value as CanvasLineCap
+                    this.lineStyle.cap = <CanvasLineCap>value
                     break
-
                 default:
-                    if (!lineParsed && dataType?.startsWith('line_')) {
-                        this.lineStyle.loadFromActionData(state)
-                        lineParsed = true
-                    }
-                    else {
-                        atEnd = true
-                    }
-                    continue  // do not increment position counter
+                    continue;
             }
-            ++state.pos;
+            delete dr[key];
         }
-        // force transparent shadow color if using old action with a shadow toggle option
+        this.lineStyle.loadFromDataRecord(ParseState.splitRecordKeys(dr, "line_"));
         if (shadowOff)
             this.shadowColor.color = "#00000000"
         // console.dir(this);
         return this;
     }
 
-    // ILayerElement
+    // IRenderable
+    /** Draws this gauge at its current `value` property onto `ctx` using `rect` dimensions for scaling. */
     render(ctx: RenderContext2D, rect: Rectangle): void {
 
         let ccw = this.direction == ArcDrawDirection.CCW  // check to invert the value for endAngle

--- a/src/modules/elements/RoundProgressGauge.ts
+++ b/src/modules/elements/RoundProgressGauge.ts
@@ -29,7 +29,7 @@ export default class RoundProgressGauge implements ILayerElement, IRenderable, I
         cap: "round"
     })
 
-    constructor(init?: Partial<RoundProgressGauge>) {
+    constructor(init?: PartialDeep<RoundProgressGauge>) {
         assignExistingProperties(this, init, 1);
     }
 

--- a/src/modules/elements/Script.ts
+++ b/src/modules/elements/Script.ts
@@ -1,0 +1,173 @@
+
+import * as vm from 'vm';
+import * as canvas from '../types';
+import * as elements from "./";
+import * as geometry from '../geometry';
+import * as utils from '../../utils';
+import { Logger, logging } from '../logging';
+import { LayerRole, ParseState } from '../'
+import { Act, Str } from '../../utils/consts';
+import { readFileSync } from 'fs';
+
+import type { ILayerElement, IRenderable, IValuedElement } from '../interfaces';
+import type { DynamicIcon, RenderContext2D } from '../'
+
+type ContextObject = vm.Context & {
+    logger: Logger,
+    parentIcon: DynamicIcon | null | undefined,
+    canvasContext: RenderContext2D | null,
+    paintRectangle: geometry.Rectangle,
+    scriptArgs: string,
+};
+
+/** This class will run a user-provided script in a (somemwhat) isolated Node VM environment.
+
+The script will be provided with the current canvas context to draw onto and the drawing area rectangle.
+An argument string can also be passed to the script.
+
+The context (environment) the script runs in contains many of the classes & utilities used internally
+(like `DOMMatrix`, `Canvas`, `loadImage()`, etc) as well as all the existing layer elements (`StyledText`, `RectanglePath`, etc).
+A `logger` instance, `console` and `require` are also provided.
+
+@internal
+*/
+export default class Script implements ILayerElement, IRenderable, IValuedElement
+{
+    /** Argument string to pass to the script's context object in `render()`. */
+    args: string = "";
+
+    #parent: WeakRef<DynamicIcon>;
+    #source: string = "";
+    #script: vm.Script | null = null;
+    #context: vm.Context | null = null;
+    #contextObj: ContextObject | null = null;
+    readonly #contextOptions: vm.CreateContextOptions = {
+        // microtaskMode: "afterEvaluate"
+    };
+    readonly #runOptions: vm.RunningScriptOptions = {
+        timeout: 3000,
+        breakOnSigint: true
+    };
+    readonly log: Logger;
+
+    constructor(init: {parentIcon: DynamicIcon} & PartialDeep<Script>) {
+        if (!init?.parentIcon)
+            throw new Error("'parentIcon' property is required in `Script` constructor's init object argument.");
+        this.#parent = new WeakRef(init.parentIcon);
+        Object.assign(this, init);
+        this.log = logging().getLogger(init.parentIcon.name);
+        this.#contextOptions.name = `VM Context for ${init.parentIcon.name}`;
+    }
+
+    // ILayerElement
+    /** @internal */
+    readonly layerRole = LayerRole.Drawable;
+
+    /** Returns true if no script source has been specified. */
+    get isEmpty(): boolean { return !this.#source; }
+
+    /** Path to script file. Relative paths are resolved against default file path configured in plugin settings, if any. */
+    get source() { return this.#source; }
+    set source(path: string) {
+        this.setSource(path);
+    }
+
+    /** Get or set the script's timeout setting. This determines how long to wait for the script to complete before killing it. */
+    get timeout() { return this.#runOptions.timeout!; }
+    set timeout(ms: number) {
+        if (ms > 0)
+            this.#runOptions.timeout = ms;
+    }
+
+    get iconName() { return this.#parent.deref()?.name ?? ""; }
+
+    // IValuedElement
+    /** Sets/updates the script arguments ({@link args} property). */
+    setValue(value: string) {
+        this.args = value;
+    }
+
+    private setSource(src: string) {
+        if (src)
+            src = utils.qualifyFilepath(src);
+        if (src !== this.#source) {
+            this.#source = src;
+            this.#script = null;
+        }
+    }
+
+    private createContext() {
+        // This object defines what is available to the script in its global context.
+        this.#contextObj = {
+            require, console,
+            ...canvas, ...geometry,
+            DI: { ...elements, ...utils },
+            logger: this.log,
+            parentIcon: null,
+            canvasContext: null,
+            paintRectangle: new geometry.Rectangle(),
+            scriptArgs: "",
+        }
+        this.#context = vm.createContext(this.#contextObj, this.#contextOptions);
+    }
+
+    private getContext(): ContextObject {
+        if (!this.#context)
+            this.createContext();
+        return this.#contextObj!;
+    }
+
+    private createScript() {
+        try {
+            const src = readFileSync(this.#source, { encoding: 'utf-8' });
+            this.#script = new vm.Script(src, this.#source);
+        }
+        catch (e: any) {
+            this.setSource("");  // reset path and script to null
+            this.log.error(`Error loading or creating script from file "${this.#source}": ${e}`);
+        }
+        return !!this.#script;
+    }
+
+    loadFromActionData(state: ParseState): Script {
+        const dr = state.asRecord(state.pos, Act.IconScript + Str.IdSep);
+        if (dr.src != undefined)
+            this.setSource(dr.src);
+        if (dr.args != undefined)
+            this.setValue(dr.args);
+        if (dr.cache == "Off")
+            this.#script = null;
+        // console.dir(this);
+        return this;
+    }
+
+    // IRenderable
+    async render(ctx: RenderContext2D, rect: geometry.Rectangle) {
+        if (!ctx || this.isEmpty)
+            return;
+        if (!this.#script && !this.createScript())
+            return;
+
+        const scriptCtx = this.getContext();
+        scriptCtx.parentIcon = this.#parent.deref();
+        scriptCtx.canvasContext = ctx;
+        scriptCtx.paintRectangle.set(rect);
+        scriptCtx.scriptArgs = this.args;
+
+        ctx.save();
+        // const start = process.hrtime.bigint();
+        try {
+            await this.#script!.runInContext(this.#context!, this.#runOptions);
+        }
+        catch (e: any) {
+            this.log.error(e, e.stack);
+        }
+        // const end = process.hrtime.bigint();
+        // this.log.debug(this.iconName, ((end - start) / 1_000n), "μs");
+        ctx.restore();
+        scriptCtx.parentIcon = null;     // don't store deref'd instance
+        scriptCtx.canvasContext = null;  // or the context
+        // console.dir(this.contextObj);
+
+    }
+}

--- a/src/modules/elements/Script.ts
+++ b/src/modules/elements/Script.ts
@@ -2,6 +2,7 @@
 import * as vm from 'vm';
 import * as canvas from '../types';
 import * as elements from "./";
+import * as enums from "../enums";
 import * as geometry from '../geometry';
 import * as utils from '../../utils';
 import { Logger, logging } from '../logging';
@@ -101,7 +102,7 @@ export default class Script implements ILayerElement, IRenderable, IValuedElemen
         this.#contextObj = {
             require, console,
             ...canvas, ...geometry,
-            DI: { ...elements, ...utils },
+            DI: { ...elements, ...utils, ...enums },
             logger: this.log,
             parentIcon: null,
             canvasContext: null,

--- a/src/modules/elements/ShadowStyle.ts
+++ b/src/modules/elements/ShadowStyle.ts
@@ -18,7 +18,7 @@ export default class ShadowStyle {
         offsetY: 0
     }
 
-    constructor(init?: Partial<ShadowStyle>) {
+    constructor(init?: PartialDeep<ShadowStyle>) {
         assignExistingProperties(this, init, 1);
     }
 

--- a/src/modules/elements/ShadowStyle.ts
+++ b/src/modules/elements/ShadowStyle.ts
@@ -1,34 +1,37 @@
 import { RenderContext2D, Vect2d } from '../';
 import { assignExistingProperties } from '../../utils';
 
+/** Stores properties for applying a shadow to a canvas context.
+Can also be used to save & restore context shadow properties. */
 export default class ShadowStyle {
-    blur: number = 0;
-    offset: Vect2d = new Vect2d();
+    /** Shadow color. */
     color: string = "#0000";
+    /** Shadow blur radius. */
+    blur: number = 0;
+    /** Shadow offset coordinates. */
+    readonly offset: Vect2d = new Vect2d();
 
-    savedContext:any = {
+    private savedContext:any = {
+        color: "black",
         blur: 0,
         offsetX: 0,
         offsetY: 0
     }
 
-    constructor(init?: Partial<ShadowStyle> | any) {
-        if (typeof init?.offset == 'number' || typeof init?.offset == 'object')
-            this.offset.set(init.offset);
-        assignExistingProperties(this, init, 0);
+    constructor(init?: Partial<ShadowStyle>) {
+        assignExistingProperties(this, init, 1);
     }
 
-    // IRenderable
-    readonly type: string = "ShadowStyle";
-    // returns true if blur and offset are are <= 0 or if color is transparent/invalid.
+    /** Returns `true` if blur and offset are are <= 0. */
     get isEmpty(): boolean { return (this.blur <= 0 && this.offset.isNull); }
 
     /** Resets shadow coordinates to zero. Does not affect color. */
-    clear() {
+    resetCoordinates() {
         this.blur = 0;
         this.offset.set(0, 0);
     }
 
+    /** Applies current shadow styling properties to the given canvas `ctx`. */
     render(ctx: RenderContext2D): void {
         if (this.isEmpty)
             return;
@@ -38,19 +41,17 @@ export default class ShadowStyle {
         ctx.shadowOffsetY = this.offset.y;
     }
 
-    /** Saves the given context's shadow coordinate properties to `ShadowStyle.savedContext` member.
-     * See also `restoreContext()`;
-     */
+    /** Saves the given context's shadow properties. See also `restoreContext()`. */
     saveContext(ctx: RenderContext2D): void {
+        this.savedContext.color = ctx.shadowColor;
         this.savedContext.blur = ctx.shadowBlur;
         this.savedContext.offsetX = ctx.shadowOffsetX;
         this.savedContext.offsetY = ctx.shadowOffsetY;
     }
 
-    /** Resets all shadow attributes on given context to the values saved in `savedContext`.
-     * See also `saveContext()`.
-      */
+    /** Resets all shadow attributes on given context to the values saved with `saveContext()`. */
     restoreContext(ctx: RenderContext2D): void {
+        ctx.shadowColor = this.savedContext.color;
         ctx.shadowBlur = this.savedContext.blur;
         ctx.shadowOffsetX = this.savedContext.offsetX;
         ctx.shadowOffsetY = this.savedContext.offsetY;

--- a/src/modules/elements/SizedElement.ts
+++ b/src/modules/elements/SizedElement.ts
@@ -14,7 +14,7 @@ export default class SizedElement
     /** Extra position offset to apply after alignment. */
     offset: PointType = Point.new();
 
-    constructor(init?: Partial<SizedElement>) {
+    constructor(init?: PartialDeep<SizedElement>) {
         assignExistingProperties(this, init, 1);
     }
 

--- a/src/modules/elements/SizedElement.ts
+++ b/src/modules/elements/SizedElement.ts
@@ -1,5 +1,5 @@
 
-import { Alignment, Point, PointType, Rectangle, SizeType, TpActionDataRecord, UnitValue, Vect2d } from '../';
+import { Alignment, Point, Rectangle, UnitValue, Vect2d } from '../';
 import { ALIGNMENT_ENUM_NAMES } from '../../utils/consts';
 import { assignExistingProperties, evaluateValue, parseAlignmentFromValue, parseAlignmentsFromString, round4p } from '../../utils';
 

--- a/src/modules/elements/StrokeStyle.ts
+++ b/src/modules/elements/StrokeStyle.ts
@@ -2,7 +2,7 @@
 import { UnitValue } from '..';
 import { BrushStyle } from '.';
 import { assignExistingProperties, evaluateValue, parseNumericArrayString, round4p } from '../../utils';
-import type { Rectangle, RenderContext2D, TpActionDataRecord } from '..';
+import type { Rectangle } from '..';
 
 /** Stores stroke (line) canvas context property definitions, which includes stroke ("pen") style, line width, cap, join, miter, and dash array properties.
 Line width can be defined as a relative % and scaled automatically in the {@link render} method.

--- a/src/modules/elements/StrokeStyle.ts
+++ b/src/modules/elements/StrokeStyle.ts
@@ -37,7 +37,7 @@ export default class StrokeStyle
     /** If the {@link width} unit type is relative (%) then returns the {@link dashOffset} value multiplied by {@link widthScale}. Otherwise just returns {@link dashOffset} unmodified. */
     get scaledDashOffset(): number { return this.width.isRelative && this.dashOffset ? round4p(this.dashOffset * this.widthScale) : this.dashOffset; }
 
-    constructor(init?: Partial<StrokeStyle | { width?: number|string, color?: string }> ) {
+    constructor(init?: PartialDeep<StrokeStyle | { width?: number|string, color?: string }> ) {
         if (typeof init?.width == 'number') {
             this.width.value = Math.abs(init.width);
         }

--- a/src/modules/elements/StyledRectangle.ts
+++ b/src/modules/elements/StyledRectangle.ts
@@ -39,7 +39,7 @@ export default class StyledRectangle extends RectanglePath implements ILayerElem
         super.loadFromDataRecord(state.asRecord(state.pos, Act.IconRect + Str.IdSep));
         // Check for shadow and line style changes which may affect cached path.
         if (this.style.loadFromDataRecord(state.asRecord(state.pos, Act.IconRect + Str.IdSep + Act.IconStyle + Str.IdSep)))
-            this.clearCahe();
+            this.clearCache();
         // console.dir(this, {depth: 5});
         return this;
     }

--- a/src/modules/elements/StyledRectangle.ts
+++ b/src/modules/elements/StyledRectangle.ts
@@ -1,10 +1,12 @@
 
-import { IColorElement, ILayerElement, IRenderable } from '../interfaces';
-import { ColorUpdateType, LayerRole, ParseState, Rectangle, RenderContext2D } from '../';
+import { ColorUpdateType, LayerRole, Rectangle, type ParseState } from '../';
 import { DrawingStyle } from './';
-import { assignExistingProperties, round3p } from '../../utils';
+import { round3p } from '../../utils';
 import { Act, Str } from '../../utils/consts';
-import RectanglePath from './RectanglePath';  // must be direct import for subclass
+import RectanglePath, { type RectanglePathInit } from './RectanglePath';  // must be direct import for subclass
+import type { IColorElement, ILayerElement, IRenderable } from '../interfaces';
+
+export type StyledRectangleInit = RectanglePathInit & PartialDeep<StyledRectangle>;
 
 /** Draws a rectangle shape on a canvas context with optional radii applied to any/all of the 4 corners (like CSS). The shape can be fully styled with the embedded `DrawingStyle` property. */
 export default class StyledRectangle extends RectanglePath implements ILayerElement, IRenderable, IColorElement
@@ -14,10 +16,10 @@ export default class StyledRectangle extends RectanglePath implements ILayerElem
     /** Whether to adjust (reduce) the overall drawing area size to account for shadow offset/blur. */
     adjustSizeForShadow: boolean = true;
 
-    constructor(init?: PartialDeep<StyledRectangle>) {
+    constructor(init?: StyledRectangleInit) {
         super();
         this.style = new DrawingStyle(init?.style);
-        assignExistingProperties(this, init, 1);
+        super.init(init);
     }
 
     // ILayerElement

--- a/src/modules/elements/StyledRectangle.ts
+++ b/src/modules/elements/StyledRectangle.ts
@@ -14,7 +14,7 @@ export default class StyledRectangle extends RectanglePath implements ILayerElem
     /** Whether to adjust (reduce) the overall drawing area size to account for shadow offset/blur. */
     adjustSizeForShadow: boolean = true;
 
-    constructor(init?: Partial<StyledRectangle>) {
+    constructor(init?: PartialDeep<StyledRectangle>) {
         super();
         this.style = new DrawingStyle(init?.style);
         assignExistingProperties(this, init, 1);

--- a/src/modules/elements/StyledRectangle.ts
+++ b/src/modules/elements/StyledRectangle.ts
@@ -2,49 +2,50 @@
 import { IColorElement, ILayerElement, IRenderable } from '../interfaces';
 import { ColorUpdateType, LayerRole, ParseState, Rectangle, RenderContext2D } from '../';
 import { DrawingStyle } from './';
-import { arraysMatchExactly, round3p } from '../../utils';
+import { assignExistingProperties, round3p } from '../../utils';
 import { Act, Str } from '../../utils/consts';
 import RectanglePath from './RectanglePath';  // must be direct import for subclass
 
-// Draws a rectangle shape on a canvas context with optional radii applied to any/all of the 4 corners (like CSS). The shape can be fully styled with the embedded DrawingStyle property.
+/** Draws a rectangle shape on a canvas context with optional radii applied to any/all of the 4 corners (like CSS). The shape can be fully styled with the embedded `DrawingStyle` property. */
 export default class StyledRectangle extends RectanglePath implements ILayerElement, IRenderable, IColorElement
 {
-    style: DrawingStyle = new DrawingStyle();
+    /** Fill and stroke style to apply when drawing this element. */
+    style: DrawingStyle;
     /** Whether to adjust (reduce) the overall drawing area size to account for shadow offset/blur. */
     adjustSizeForShadow: boolean = true;
 
-    // constructor(init?: Partial<StyledRectangle> | any) { assignExistingProperties(this, init, 0); }
+    constructor(init?: Partial<StyledRectangle>) {
+        super();
+        this.style = new DrawingStyle(init?.style);
+        assignExistingProperties(this, init, 1);
+    }
 
     // ILayerElement
-    readonly type: string = "StyledRectangle";
+    /** @internal */
     readonly layerRole: LayerRole = LayerRole.Drawable;
 
     /** Returns true if there is nothing to draw: there is no fill and stroke width is zero */
     get isEmpty(): boolean {
-        return this.style.fill.isEmpty && this.style.line.isEmpty;
+        return this.style.fill.isEmpty && this.style.stroke.isEmpty;
     }
 
     // IColorElement
+    /** @internal */
     setColor(value: string, type: ColorUpdateType): void { this.style.setColor(value, type); }
 
+    /** @internal */
     loadFromActionData(state: ParseState): StyledRectangle {
-        super.loadFromActionData(state, Act.IconRect);
-        const stylePos = state.data.findIndex(v => v.id.includes(Act.IconStyle + Str.IdSep, (Str.IdPrefix + Act.IconRect).length));
-        if (stylePos < 0)
-            return this;  // ulikely
+        // const dr = state.dr;
+        super.loadFromDataRecord(state.asRecord(state.pos, Act.IconRect + Str.IdSep));
         // Check for shadow and line style changes which may affect cached path.
-        const sarry = this.adjustSizeForShadow ? [this.style.shadow.blur, this.style.shadow.offset.x, this.style.shadow.offset.y] : null;
-        const lw = this.style.line.width;
-        this.style.loadFromActionData(state.setPos(stylePos));
-        if (lw.value != this.style.line.width.value ||
-                lw.isRelative != this.style.line.width.isRelative ||
-                (sarry && !arraysMatchExactly(sarry, [this.style.shadow.blur, this.style.shadow.offset.x, this.style.shadow.offset.y])))
-            this.cache.clear();
+        if (this.style.loadFromDataRecord(state.asRecord(state.pos, Act.IconRect + Str.IdSep + Act.IconStyle + Str.IdSep)))
+            this.clearCahe();
         // console.dir(this, {depth: 5});
         return this;
     }
 
-    // ILayerElement
+    // IRenderable
+    /** Draws the rectangle with all styling and positioning options applied onto `ctx` using `rect` dimensions for scaling and alignment. */
     render(ctx: RenderContext2D, rect: Rectangle): void { this.renderImpl(ctx, rect); }
 
     /** The actual drawing implementation. May be used by subclasses.
@@ -57,12 +58,12 @@ export default class StyledRectangle extends RectanglePath implements ILayerElem
 
         // set stroke scaling and adjust drawing size if needed
         let penW = 0, penW2 = 0;
-        if (!this.style.line.isEmpty) {
+        if (!this.style.stroke.isEmpty) {
             // relative stroke width is percentage of half the overall size where 100% would be half the smaller of width/height (and strokes would overlay the whole shape)
-            if (this.style.line.width.isRelative)
-                this.style.line.widthScale = Math.min(window.width, window.height) * .005;
+            if (this.style.stroke.width.isRelative)
+                this.style.stroke.widthScale = Math.min(window.width, window.height) * .005;
             // adjust size to prevent clipping of stroke which is drawn middle-aligned on the shape border
-            penW = this.style.line.scaledWidth;
+            penW = this.style.stroke.scaledWidth;
             penW2 = round3p(penW * .5);
             window.adjust(penW2, -penW);
         }

--- a/src/modules/elements/StyledText.ts
+++ b/src/modules/elements/StyledText.ts
@@ -9,10 +9,7 @@ import {
 import { Act, Str } from '../../utils/consts';
 
 import type { IColorElement, ILayerElement, IRenderable, IValuedElement } from '../interfaces';
-import type {
-    CanvasTextAlign, CanvasTextBaseline, ColorUpdateType,
-    Path2D, PointType, Rectangle, RenderContext2D, TextMetrics,
-} from '../';
+import type { ColorUpdateType, Path2D, Rectangle, } from '../';
 
 /** Draws text on a canvas context with various options. The text can be fully styled with the embedded {@link style} {@link DrawingStyle} property. */
 export default class StyledText implements ILayerElement, IRenderable, IValuedElement, IColorElement

--- a/src/modules/elements/StyledText.ts
+++ b/src/modules/elements/StyledText.ts
@@ -1,43 +1,62 @@
 
-import { Alignment, Point, UnitValue } from '../';
-import { assignExistingProperties, evaluateValue, evaluateStringValue, parseAlignmentFromValue } from '../../utils'
+import { Alignment, LayerRole, ParseState, Point, UnitValue, Vect2d } from '../';
 import { DrawingStyle } from './';
+import {
+    ALIGNMENT_ENUM_NAMES,
+    assignExistingProperties, evaluateValue, evaluateStringValue,
+    parseAlignmentFromValue, parseAlignmentsFromString,
+} from '../../utils'
+import { Act, Str } from '../../utils/consts';
 
 import type { IColorElement, ILayerElement, IRenderable, IValuedElement } from '../interfaces';
-import type { ColorUpdateType, ParseState, PointType, Rectangle, RenderContext2D, TextMetrics, } from '../';
+import type {
+    CanvasTextAlign, CanvasTextBaseline, ColorUpdateType,
+    Path2D, Rectangle, RenderContext2D, TextMetrics,
+} from '../';
 
-export type CssTextDirection = 'ltr' | 'rtl' | 'inherit';
-
-// Draws text on a canvas context with various options. The text can be fully styled with the embedded DrawingStyle property.
+/** Draws text on a canvas context with various options. The text can be fully styled with the embedded {@link style} {@link DrawingStyle} property. */
 export default class StyledText implements ILayerElement, IRenderable, IValuedElement, IColorElement
 {
+    /** The default font variant ensures ligature support, especially useful for named symbol fonts. */
+    static readonly defaultFontVariant = 'common-ligatures discretionary-ligatures contextual';
+
+    /** How to align the text within given drawing area. See also {@link align}, {@link valign}, {@link halign} properties. */
     alignment: Alignment = Alignment.CENTER;
-    offset: PointType = Point.new();
+    /** Extra position offset to apply after alignment. Expressed as a percentage of overall drawing area size. */
+    readonly offset: Vect2d;
+    /** All visual styling options to apply when drawing the text. */
     readonly style: DrawingStyle;
+
     // These are all private because changing them will affect the cached text metrics.
-    // Value string can be accessed with value/setValue(). Other accessors can be added as needed.
     #text: string = "";
     #font: string = "";
-    #fontVariant: string = 'common-ligatures discretionary-ligatures contextual';  // ensure ligature support for named symbol fonts
-    #direction: CssTextDirection = 'inherit';
-    #letterSpacing: UnitValue = new UnitValue(0, "em");
+    #variant: string = StyledText.defaultFontVariant;
+    #smallCaps: string = "";
+    #direction: CanvasDirection = 'inherit';
+    #letterSpacing: UnitValue = new UnitValue(0, "px");
+    #wordSpacing: UnitValue = new UnitValue(0, "px");
+    #decoration: string = "";
+    #stretch: CanvasFontStretch | '' = "";
     #wrap: boolean = true;
+    #hinting: boolean = true;   // looks & aligns better with most fonts
+    #tm: TextMetrics | null = null;  // cached as needed
 
-    private tm: TextMetrics | null = null;
-
-    constructor(init?: Partial<StyledText> | any) {
-        assignExistingProperties(this, init, 1);
+    constructor(init?: Partial<StyledText>) {
+        this.offset = new Vect2d(init?.offset);
         this.style = new DrawingStyle(init?.style);
+        assignExistingProperties(this, init, 0);
     }
 
     // ILayerElement
-    readonly type: string = "StyledText";
+    /** @internal */
+    readonly layerRole: LayerRole = LayerRole.Drawable;
 
-    /** Returns true if there is nothing to draw: text is empty, colors are blank or transparent, or there is no fill and stroke width is zero */
+    /** Returns `true` if there is nothing to draw: text is empty, colors are blank or transparent, or there is no fill and stroke width is zero */
     get isEmpty(): boolean {
-        return !this.#text || (this.style.fill.isEmpty && this.style.line.isEmpty);
+        return !this.#text || (this.style.fill.isEmpty && this.style.stroke.isEmpty);
     }
 
+    /** The text to draw. May contain `\n` control characters for multi-line text (unless the {@link wrap} property is disabled). */
     get text() { return this.#text; }
     set text(text: string) {
         if (this.#text != text) {
@@ -46,32 +65,55 @@ export default class StyledText implements ILayerElement, IRenderable, IValuedEl
         }
     }
 
+    /** Font is specified as a single CSS/CanvasRenderingContext2D style string expression which may contain size, family, and other options.
+        See https://developer.mozilla.org/en-US/docs/Web/CSS/font for reference.
+
+        Note that only the following generic font family names are supported: `serif`, `sans-serif`, `monospace`, and `system-ui`.
+    */
     get font() { return this.#font; }
     set font(fontspec: string) {
         if (this.#font != fontspec) {
             this.#font = fontspec;
-            this.style.line.widthScale = 1;  // depends on font, reset it
+            // if user specified a "small-caps" variant in the font spec then we need to also
+            // include that when setting `ctx.fontVariant` since it overrides the variant set in `ctx.font`.
+            this.#smallCaps = fontspec.includes("small-caps") ? " small-caps" : "";
+            this.style.stroke.widthScale = 1;  // depends on font, reset it
             this.resetMetrics();
         }
     }
 
-    get fontVariant() { return this.#fontVariant; }
+    /** The font variant(s) can be specified separately from what is allowed in {@link font} because this way supports more variant types than just "small-caps".
+        The full range of CSS [font-variant](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant) values can be used. Multiple values should
+        be separated by spaces.
+
+        The default variants, specified in the {@link StyledText.defaultFontVariant} static property, add support for ligatures. To preserve
+        this support while adding other variant(s), use the static property and add the desired variant(s) to that after a space. Eg.
+        ```js
+            styledText.fontVariant = StyledText.defaultFontVariant + " titling-caps slashed-zero";
+        ```
+
+        Note: If "small-caps" was specified in the {@link font} property, then it will automatically be added to the current `fontVariant`
+        inside the `render()` method (there's no need to specify it separately as a value for this property).
+    */
+    get fontVariant() { return this.#variant; }
     set fontVariant(variant: string) {
-        if (this.#fontVariant != variant) {
-            this.#fontVariant = variant;
-            this.style.line.widthScale = 1;  // depends on font, reset it
+        if (this.#variant != variant) {
+            this.#variant = variant;
+            this.style.stroke.widthScale = 1;  // depends on font, reset it
             this.resetMetrics();
         }
     }
 
+    /** Text drawing direction: 'ltr', 'rtl', or 'inherit' (default). */
     get direction() { return this.#direction; }
-    set direction(dir: CssTextDirection) {
+    set direction(dir: CanvasDirection) {
         if (this.#direction != dir) {
             this.#direction = dir;
             this.resetMetrics();
         }
     }
 
+    /** Letter spacing property expressed as a CSS `length` value, eg: "2px" or "1em". Default is `0px`. */
     get letterSpacing() { return this.#letterSpacing.toString(); }
     set letterSpacing(spacing: string) {
         if (this.letterSpacing != spacing) {
@@ -80,6 +122,40 @@ export default class StyledText implements ILayerElement, IRenderable, IValuedEl
         }
     }
 
+    /** Word spacing property expressed as a CSS `length` value, eg: "2px" or "1em". Default is `0px`. */
+    get wordSpacing() { return this.#wordSpacing.toString(); }
+    set wordSpacing(spacing: string) {
+        if (this.wordSpacing != spacing) {
+            this.#wordSpacing.setFromString(spacing);
+            this.resetMetrics();
+        }
+    }
+
+    /** The `fontStretch` property specifies how the font may be expanded or condensed when drawing text.
+        Value is one of: `ultra-condensed`, `extra-condensed`, `condensed`, `semi-condensed`, `normal` (default),
+        `semi-expanded`, `expanded`, `extra-expanded`, `ultra-expanded` */
+    get fontStretch() { return this.#stretch || 'normal'; }
+    set fontStretch(value: CanvasFontStretch) {
+        if (this.#stretch != value) {
+            this.#stretch = value;
+            this.resetMetrics();
+        }
+    }
+
+    /** The `textDecoration` property can be assigned a string using the same syntax as the CSS
+        [text-decoration](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration) property.
+        Set it to `none` or an empty value to draw undecorated text (default). */
+    get textDecoration() { return this.#decoration; }
+    set textDecoration(value: string) {
+        if (this.#decoration != value) {
+            this.#decoration = value;
+            this.resetMetrics();
+        }
+    }
+
+    /** Specifies whether drawn text should be wrapped.
+        Currently only has any effect when {@link text} contains `\n` controls characters (there is no auto-wrapping).
+        It can be set to `false` to prevent wrapping (in which case any `\n` in the text will be ignored). */
     get wrap() { return this.#wrap; }
     set wrap(wrap: boolean) {
         if (this.#wrap != wrap) {
@@ -88,117 +164,158 @@ export default class StyledText implements ILayerElement, IRenderable, IValuedEl
         }
     }
 
-    get horizontalAlignment() { return (this.alignment & Alignment.H_MASK); }
-    set horizontalAlignment(value: string | Alignment) {
-        let a: Alignment;
-        if (typeof value == "number")
-            a = value;
-        else
-            a = parseAlignmentFromValue(value, Alignment.H_MASK);
-        this.alignment &= ~Alignment.H_MASK;
-        this.alignment |= a;
+    /** Enables or disables font hinting when drawing text and calculating metrics (for alignment). Default is enabled. */
+    get fontHinting() { return this.#hinting; }
+    set fontHinting(value: boolean) {
+        if (this.#hinting != value) {
+            this.#hinting = value;
+            this.resetMetrics();
+        }
     }
 
-    get verticalAlignment() { return (this.alignment & Alignment.V_MASK); }
-    set verticalAlignment(value: string | Alignment) {
-        let a: Alignment;
-        if (typeof value == "number")
-            a = value;
-        else
-            a = parseAlignmentFromValue(value, Alignment.V_MASK);
-        this.alignment &= ~Alignment.V_MASK;
-        this.alignment |= a;
+    /** Alignment value as two string values, one for each direction. Eg. "left top" or "middle center".
+    Setting the property can be done with either a single direction or both (separated by space or comma) in either order. */
+    get align(): string {
+         return ALIGNMENT_ENUM_NAMES[this.alignment & Alignment.H_MASK] + ' ' + ALIGNMENT_ENUM_NAMES[this.alignment & Alignment.V_MASK];
+    }
+    set align(value: string | Alignment) {
+        if (typeof value == 'string')
+            value = parseAlignmentsFromString(value);
+        let mask = (value & Alignment.H_MASK) ? Alignment.H_MASK : Alignment.NONE;
+        if (value & Alignment.V_MASK)
+            mask |= Alignment.V_MASK;
+        this.setAlignment(value, mask);
+    }
+
+    /** Horizontal alignment value as string. One of: 'left', 'center', 'right' */
+    get halign(): CanvasTextAlign { return ALIGNMENT_ENUM_NAMES[this.alignment & Alignment.H_MASK]; }
+    set halign(value: CanvasTextAlign | Alignment) {
+        if (typeof value == 'string')
+            value = parseAlignmentFromValue(value, Alignment.H_MASK);
+        this.setAlignment(value, Alignment.H_MASK);
+    }
+
+    /** Vertical alignment value as string. One of: 'top', 'middle', 'bottom', 'baseline' */
+    get valign(): CanvasTextBaseline { return ALIGNMENT_ENUM_NAMES[this.alignment & Alignment.V_MASK]; }
+    set valign(value: CanvasTextBaseline | Alignment) {
+        if (typeof value == 'string')
+            value = parseAlignmentFromValue(value, Alignment.V_MASK);
+        this.setAlignment(value, Alignment.V_MASK);
+    }
+
+    /** Returns true if alignment value was changed, false otherwise. Direction to set can be limited by `mask` argument. */
+    setAlignment(value: Alignment, mask: Alignment = Alignment.H_MASK | Alignment.V_MASK): boolean {
+        if ((this.alignment & mask) != value) {
+            this.alignment &= ~mask;
+            this.alignment |= value;
+            return true;
+        }
+        return false;
     }
 
     // IValuedElement
+    /** Sets the current {@link StyledText#text} property from an evaluated input string (embedded JS is resolved). */
     setValue(text: string): void {
         this.text = evaluateStringValue(text);
     }
 
     // IColorElement
+    /** @internal */
     setColor(value: string, type: ColorUpdateType): void { this.style.setColor(value, type); }
 
+    // ILayerElement
+    /** @internal */
     loadFromActionData(state: ParseState): StyledText {
-        let styleParsed = false;
-        for (let i = state.pos, e = state.data.length; i < e; ++i) {
-            const data = state.data[i];
-            const dataType = data.id.split('text_').at(-1);  // last part of the data ID determines its meaning
-            switch (dataType) {
+        const dr = state.asRecord(state.pos, Act.IconText + Str.IdSep);
+        for (const [key, value] of Object.entries(dr)) {
+            switch (key) {
                 case 'str':
-                    this.setValue(data.value);
+                    this.setValue(value);
                     break;
                 case 'font':
-                    this.font = data.value.trim();
+                    this.font = value.trim();
                     break;
                 case 'alignH':
-                    this.horizontalAlignment = data.value;
+                    this.halign = <CanvasTextAlign>value;
                     break;
                 case 'alignV':
-                    this.verticalAlignment = data.value;
+                    this.valign = <CanvasTextBaseline>value;
                     break;
                 case 'ofsH':
-                    this.offset.x = evaluateValue(data.value);
+                    this.offset.x = evaluateValue(value);
                     break;
                 case 'ofsV':
-                    this.offset.y = evaluateValue(data.value);
+                    this.offset.y = evaluateValue(value);
                     break;
-                case 'tracking': {
+                case 'tracking':
                     // the deprecated skia-canvas textTracking value was a signed int representing 1/1000 of an 'em'
-                    const v = (parseFloat(data.value) || 0) / 1000;
-                    if (v != this.#letterSpacing.value) {
-                        this.#letterSpacing.value = v;
-                        this.resetMetrics();
-                    }
+                    this.letterSpacing = (parseFloat(value) || 0) / 1000 + 'em';
                     break;
-                }
-                default: {
-                    if (styleParsed || !dataType || !dataType.startsWith('style_')) {
-                        i = e;  // end loop
-                        continue;
-                    }
-                    // any other fields should be styling data
-                    this.style.loadFromActionData(state);
-                    styleParsed = true;
-                    i = state.pos;
+                default:
                     continue;
-                }
             }
-            ++state.pos;
+            delete dr[key];
         }
+        this.style.loadFromDataRecord(ParseState.splitRecordKeys(dr, Act.IconStyle + Str.IdSep));
         // console.dir(this);
         return this;
     }
 
+    /** Clears any cached text metrics. Typically the cache management is handled automatically when relevant properties are modified. */
     resetMetrics() {
-        this.tm = null;
+        this.#tm = null;
     }
 
-    // ILayerElement
+    protected applyCommonContextProperties(ctx: RenderContext2D) {
+        ctx.font = this.#font;
+        ctx.fontVariant = this.#variant + this.#smallCaps as any;  // FontVariantSetting
+        ctx.direction = this.#direction;
+        ctx.textWrap = this.#wrap;
+        ctx.textAlign = this.halign;
+        ctx.fontHinting = this.#hinting;
+        if (!!this.#letterSpacing.value)
+            ctx.letterSpacing = this.letterSpacing;
+        if (!!this.#wordSpacing.value)
+            ctx.wordSpacing = this.wordSpacing;
+        if (!!this.#decoration)
+            ctx.textDecoration = this.#decoration;
+        if (!!this.#stretch)
+            ctx.fontStretch = this.#stretch;
+    }
+
+    /** Returns the current {@link text} outline as a `Path2D` object, taking into account all current typography settings (e.g., font, alignment, wrapping, etc.).
+        The path is not scaled and has a 0,0 origin point, so typically it would need to be scaled and aligned separately within a container (eg. by {@link FreeformPath}).
+        If a positive `maxWidth` is given and {@link wrap} property is `true` then the text will be word-wrapped to the given width if needed.
+    */
+    asPath(ctx: RenderContext2D, maxWidth?: number): Path2D {
+        ctx.save();
+        this.applyCommonContextProperties(ctx);
+        ctx.textBaseline = this.valign;
+        const path = ctx.outlineText(this.#text, maxWidth);
+        ctx.restore();
+        return path;
+    }
+
+    // IRenderable
+    /** Draws the current {@link text} value with all styling and positioning options applied onto `ctx` using `rect` dimensions for scaling and alignment. */
     render(ctx: RenderContext2D, rect: Rectangle): void {
         // console.dir(this);
         if (!ctx || this.isEmpty)
             return;
 
         ctx.save();
-
-        ctx.font = this.#font;
-        ctx.fontVariant = this.#fontVariant as any;  // FontVariantSetting
-        ctx.direction = this.#direction;
-        ctx.textWrap = this.#wrap;
-        ctx.fontHinting = true;  // looks & aligns better with most fonts
-        if (this.#letterSpacing.value)
-            ctx.letterSpacing = this.#letterSpacing.toString();
+        this.applyCommonContextProperties(ctx);
 
         // Calculate the stroke width first, if any.
         let penAdjust = 0;
-        if (!this.style.line.isEmpty) {
-            if (this.style.line.width.isRelative && this.style.line.widthScale == 1) {
+        if (!this.style.stroke.isEmpty) {
+            if (this.style.stroke.width.isRelative && this.style.stroke.widthScale == 1) {
                 // stroke line width is percentage of half the font size; only calculate if we haven't already.
                 const charMetric:any = ctx.measureText("W");
-                this.style.line.widthScale = Math.max(charMetric.width, charMetric.fontBoundingBoxAscent + charMetric.fontBoundingBoxDescent) * .005;
+                this.style.stroke.widthScale = Math.max(charMetric.width, charMetric.fontBoundingBoxAscent + charMetric.fontBoundingBoxDescent) * .005;
             }
             // need to offset the draw origin by half of the line width, otherwise it may clip off an edge
-            penAdjust = this.style.line.scaledWidth * .5;
+            penAdjust = this.style.stroke.scaledWidth * .5;
             // save the current context shadow settings -- we may need to restore these before drawing the stroke (if we also have a fill).
             this.style.shadow.saveContext(ctx);
         }
@@ -212,18 +329,15 @@ export default class StyledText implements ILayerElement, IRenderable, IValuedEl
         switch (this.alignment & Alignment.H_MASK) {
             case Alignment.HCENTER:
             case Alignment.JUSTIFY:
-                ctx.textAlign = 'center';
-                if (!this.tm)
-                    this.tm = ctx.measureText(this.#text);
-                offset.x = (rect.width * 0.5 - this.tm.actualBoundingBoxLeft + this.tm.actualBoundingBoxRight);
+                if (!this.#tm)
+                    this.#tm = ctx.measureText(this.#text);
+                offset.x = (rect.width * 0.5 - this.#tm.actualBoundingBoxLeft + this.#tm.actualBoundingBoxRight);
                 break;
             case Alignment.LEFT:
-                ctx.textAlign = 'left';
                 // add some left padding
                 offset.x = rect.width * .015 + penAdjust;
                 break;
             case Alignment.RIGHT:
-                ctx.textAlign = 'right';
                 // add some right padding
                 offset.x = rect.width - rect.width * .015 - penAdjust;
                 break;
@@ -231,9 +345,9 @@ export default class StyledText implements ILayerElement, IRenderable, IValuedEl
         // vertical
         switch (this.alignment & Alignment.V_MASK) {
             case Alignment.VCENTER:
-                if (!this.tm)
-                    this.tm = ctx.measureText(this.#text);
-                offset.y = (rect.height - this.tm.actualBoundingBoxAscent - this.tm.actualBoundingBoxDescent) * 0.5 + this.tm.actualBoundingBoxAscent;
+                if (!this.#tm)
+                    this.#tm = ctx.measureText(this.#text);
+                offset.y = (rect.height - this.#tm.actualBoundingBoxAscent - this.#tm.actualBoundingBoxDescent) * 0.5 + this.#tm.actualBoundingBoxAscent;
                 break;
             case Alignment.TOP:
                 // no extra padding needed here since using "top" as baseline adds some already
@@ -241,10 +355,11 @@ export default class StyledText implements ILayerElement, IRenderable, IValuedEl
                 offset.y = penAdjust;
                 break;
             case Alignment.BOTTOM:
-                if (!this.tm)
-                    this.tm = ctx.measureText(this.#text);
+            case Alignment.BASELINE:
+                if (!this.#tm)
+                    this.#tm = ctx.measureText(this.#text);
                 // needs a little bottom padding to match spacing of top aligned text
-                offset.y = rect.height - this.tm.actualBoundingBoxDescent - penAdjust - rect.height * .015;
+                offset.y = rect.height - this.#tm.actualBoundingBoxDescent - penAdjust - rect.height * .015;
                 break;
         }
         // console.log(this.text, this.font, rect.size, offset, penAdjust, this.tm);

--- a/src/modules/elements/StyledText.ts
+++ b/src/modules/elements/StyledText.ts
@@ -11,7 +11,7 @@ import { Act, Str } from '../../utils/consts';
 import type { IColorElement, ILayerElement, IRenderable, IValuedElement } from '../interfaces';
 import type {
     CanvasTextAlign, CanvasTextBaseline, ColorUpdateType,
-    Path2D, Rectangle, RenderContext2D, TextMetrics,
+    Path2D, PointType, Rectangle, RenderContext2D, TextMetrics,
 } from '../';
 
 /** Draws text on a canvas context with various options. The text can be fully styled with the embedded {@link style} {@link DrawingStyle} property. */
@@ -41,7 +41,7 @@ export default class StyledText implements ILayerElement, IRenderable, IValuedEl
     #hinting: boolean = true;   // looks & aligns better with most fonts
     #tm: TextMetrics | null = null;  // cached as needed
 
-    constructor(init?: Partial<StyledText>) {
+    constructor(init?: PartialDeep<StyledText> & { offset?: number|PointType }) {
         this.offset = new Vect2d(init?.offset);
         this.style = new DrawingStyle(init?.style);
         assignExistingProperties(this, init, 0);

--- a/src/modules/elements/Transformation.ts
+++ b/src/modules/elements/Transformation.ts
@@ -1,203 +1,216 @@
 
 import { ILayerElement, IRenderable } from '../interfaces';
-import {
-    Canvas, DOMMatrix, LayerRole, Path2D, ParseState, Point, PointType,
-    Rectangle, RenderContext2D, Size, SizeType, TransformOpType
-} from '../';
+import { Canvas, DOMMatrix, LayerRole, Point, Size, TransformOpType, Vect2d } from '../';
 import { DEFAULT_TRANSFORM_OP_ORDER } from '../../utils/consts';
-import { arraysMatchExactly, evaluateValue, fuzzyEquals4p, round4p /* , parsePointFromValue */ } from '../../utils';
+import { assignExistingProperties, arraysMatchExactly, evaluateValue, fuzzyEquals4p, round4p } from '../../utils';
+import type { ParseState, Path2D, PointType, Rectangle, RenderContext2D, SizeType, TpActionDataRecord } from '../';
 
 export const enum TransformScope {
-    PreviousOne,  // affects only the layer before the transform
-    Cumulative,   // affects all previous layers drawn so far
-    UntilReset,   // affects all layers until an empty transform (or end)
-    Reset,        // resets one previous `UntilReset` transform
+    /** affects only the layer before the transform */
+    PreviousOne,
+    /** affects all previous layers drawn so far */
+    Cumulative,
+    /** affects all layers until an empty transform (or end) */
+    UntilReset,
+    /** resets one previous `UntilReset` transform */
+    Reset,
 }
 
+/** Applies a matrix transformation to a canvas context.
+
+Transform operations are specified as individual steps (eg. rotate, translate) and then combined in the specified {@link order}
+into a {@link DOMMatrix} which can then be queried with {@link toMatrix} and {@link getMatrix} or
+applied to a context or a `Path2D` path in the {@link render} or {@link transformPaths} methods, respectively.
+
+The primary difference between this class and a regular `DOMMatrix` (or transforming a canvas directly) is that all the terms
+used in `Transformation` are relative to a given size when queried or drawn. The values for all operations are specified as percentages,
+not literal pixels. The query and drawing methods all require a rectangle (or size and origin point) to scale the final matrix into.
+
+It employs a caching strategy to avoid re-computing the final matrix if input parameters and the drawing bounds do not change between
+calls to the `render()`, `transformPaths()` or `getMatrix()` methods.
+*/
 export default class Transformation implements ILayerElement, IRenderable
 {
-    // Coordinates are stored as decimals as used in matrix transform operations.
-    rotate: number = 0; // percent of 360 degrees
-    scale: PointType = Point.new(); // percent of requested image size (not the original source image), eg: 2.0 is double size, 0.5 is half size.
-    translate: PointType = Point.new(); // percentage of relevant dimension of requested image size
-                                        // eg: x = 1 translates one full image width to the right (completely out of frame for an unscaled source image)
-    skew: PointType = Point.new(); // percent of requested image size (not the original source image)
-    transformOrder: TransformOpType[] = DEFAULT_TRANSFORM_OP_ORDER;  // careful! reference... don't edit, replace entirely.
-    scope: TransformScope = TransformScope.PreviousOne;
-
-    private cache = {
+    #rotate = 0;                   // percent of 360 degrees
+    #scale = new Vect2d(100, 100); // percentage of relevant dimension of requested size
+    #translate = new Vect2d();     //
+    #skew = new Vect2d();          //
+    #transformOrder = DEFAULT_TRANSFORM_OP_ORDER;  // careful! reference... don't edit, replace entirely.
+    #scope = TransformScope.PreviousOne;
+    #cache = {
         matrix: <DOMMatrix | null> null,
         origin: <PointType | null> null,
         size: <SizeType | null> null,
     }
 
-    constructor(init?: Partial<Transformation>) { Object.assign(this, init); }
+    constructor(init?: Partial<Transformation>) {
+        assignExistingProperties(this, init, 0);
+    }
 
     // ILayerElement
-    readonly type = "Transformation";
+    /** @internal */
     readonly layerRole: LayerRole = LayerRole.Transform;
 
+    /** Returns `true` if this transform has no operations to perform. */
     get isEmpty(): boolean {
-        return this.scope == TransformScope.Reset || (fuzzyEquals4p(this.rotate, 0) && Point.fuzzyIsNull(this.translate) && Point.fuzzyIsNull(this.skew) && !this.isScaling);
+        return this.#scope == TransformScope.Reset || (fuzzyEquals4p(this.#rotate, 0) && this.#translate.fuzzyIsNull && this.#skew.fuzzyIsNull && !this.isScaling);
     }
+    /** Returns `true` if this transformation has a scaling component. */
     get isScaling(): boolean {
-        return !Point.fuzzyEquals(this.scale, {x:100,y:100});
+        return !this.#scale.fuzzyIsNull;
     }
 
-    loadFromActionData(state: ParseState): Transformation {
-        // the incoming data IDs should be structured with a naming convention
-        // For properties with X,Y values, this currently can handle both single and double-field versions (X and Y are separate fields),
-        // though currently no actions use the single field variant so this could be trimmed down if no use is found for that option.
-        let atEnd = false, dirty = false, tmp;
-        for (const e = state.data.length; state.pos < e && !atEnd;) {
-            const data = state.data[state.pos];
-            const dataType = data.id.split('tx_').at(-1);  // last part of the data ID determines its meaning
-            switch (dataType) {
-                case 'rot':
-                    if (this.rotate != (tmp = evaluateValue(data.value))) {
-                        this.rotate = tmp;
-                        dirty = true;
-                    }
-                    break;
-                case 'trsX':
-                    if (this.translate.x != (tmp = evaluateValue(data.value))) {
-                        this.translate.x = tmp;
-                        dirty = true;
-                    }
-                    break;
-                case 'trsY':
-                    if (this.translate.y != (tmp = data.value.trim() ? evaluateValue(data.value) : this.translate.x)) {
-                        this.translate.y = tmp;
-                        dirty = true;
-                    }
-                    break;
-                case 'sclX':
-                    if (this.scale.x != (tmp = evaluateValue(data.value))) {
-                        this.scale.x = tmp;
-                        dirty = true;
-                    }
-                    break;
-                case 'sclY':
-                    if (this.scale.y != (tmp = data.value.trim() ? evaluateValue(data.value) : this.scale.x)) {
-                        this.scale.y = tmp;
-                        dirty = true;
-                    }
-                    break;
-                case 'skwX':
-                    if (this.skew.x != (tmp = evaluateValue(data.value))) {
-                        this.skew.x = tmp;
-                        dirty = true;
-                    }
-                    break;
-                case 'skwY':
-                    if (this.skew.y != (tmp = data.value.trim() ? evaluateValue(data.value) : this.skew.x)) {
-                        this.skew.y = tmp;
-                        dirty = true;
-                    }
-                    break;
-                /* these 3 cases allow for X[,Y] coordinates to be specified in one data field, however they're currently unused by any action
-                case 'trs':
-                    Point.set(this.translate, parsePointFromValue(data.value));
-                    break;
-                case 'scl':
-                    Point.set(this.scale, parsePointFromValue(data.value));
-                    break;
-                case 'skw':
-                    Point.set(this.skew, parsePointFromValue(data.value));
-                    break;
-                */
-                case 'order': {
-                    if (data.value) {
-                        const order = data.value.split(', ') as TransformOpType[];
-                        if (!arraysMatchExactly(this.transformOrder, order)) {
-                            this.transformOrder = order;
-                            dirty = true;
-                        }
-                    }
-                    break;
-                }
-                case 'scope': {
-                    let scope: TransformScope | null = null;
-                    // "previous layer", "all previous", "all following", "reset following"
-                    if (data.value[0] == 'p')
-                        scope = TransformScope.PreviousOne;
-                    else if (data.value[4] == 'p')
-                        scope = TransformScope.Cumulative;
-                    else if (data.value[4] == 'f')
-                        scope = TransformScope.UntilReset;
-                    else if (data.value[0] == 'r')
-                        scope = TransformScope.Reset;
-                    if (scope && scope != this.scope) {
-                        this.scope = scope;
-                        dirty = true;
-                    }
-                    break;
-                }
-                default:
-                    atEnd = true;
-                    continue;
-            }
-            ++state.pos;
+    /** Rotation component of the transform expressed as percent of 360 degrees (eg. 50 % = 180 degrees). */
+    get rotate() { return this.#rotate; }
+    set rotate(percent: number) {
+        if (percent != this.#rotate) {
+            this.#rotate = percent;
+            this.clearCache();
         }
-        if (dirty)
-            this.cache.matrix = null;
+    }
+
+    /** Translation component expressed as percentage of relevant dimension of requested size; eg: x = 100 translates one full width to the right. */
+    get translate() { return this.#translate; }
+    set translate(percent: PointType) {
+        if (!this.#translate.equals(percent)) {
+            this.#translate.set(percent);
+            this.clearCache();
+        }
+    }
+
+    /** Scaling component expressed as percent of requested size, eg: 200.0 is double size, 50 is half size. */
+    get scale() { return this.#scale; }
+    set scale(percent: PointType) {
+        if (!this.#scale.equals(percent)) {
+            this.#scale.set(percent);
+            this.clearCache();
+        }
+    }
+
+    /** Skewing component expressed as percent of requested size. */
+    get skew() { return this.#skew; }
+    set skew(percent: PointType) {
+        if (!this.#skew.equals(percent)) {
+            this.#skew.set(percent);
+            this.clearCache();
+        }
+    }
+
+    /** The order in which to apply transform component operations. Expressed as an array of operations where each operation is one of:
+    ```
+        "O"  - Offset (translate)
+        "R"  - Rotate
+        "SC" - Scale
+        "SK" - Skew
+    ```
+    */
+    get order() { return this.#transformOrder; }
+    set order(order: TransformOpType[]) {
+        if (!arraysMatchExactly(this.#transformOrder, order)) {
+            this.#transformOrder = order;
+            this.clearCache();
+        }
+    }
+
+    /** The transformation scope affects which layer(s) of a layered icon or paths of a paths array are affected by this transform.
+    Valid string values for setting this property are one of: "previous layer", "all previous", "all following", "reset [following]"
+    Only relevant when using {@link render} or {@link transformPaths} methods. For `transformPaths()`, only the first two scopes are relevant.
+    When reading the property it is always returned as a numeric enumeration type.
+    */
+    get scope(): TransformScope { return this.#scope; }
+    set scope(scope: TransformScope | string) {
+        if (typeof scope == 'string') {
+            // "previous layer", "all previous", "all following", "reset following"
+            if (scope[0] == 'p')
+                scope = TransformScope.PreviousOne;
+            else if (scope[4] == 'p')
+                scope = TransformScope.Cumulative;
+            else if (scope[4] == 'f')
+                scope = TransformScope.UntilReset;
+            else if (scope[0] == 'r')
+                scope = TransformScope.Reset;
+            else
+                return;
+        }
+        this.#scope = scope;
+    }
+
+    /** Clears the cached transform matrix. Typically the cache management is handled automatically when relevant properties are modified. */
+    clearCache() { this.#cache.matrix = null; }
+
+    /** Returns `true` if any properties were modified or cached matrix hasn't been generated yet.
+        @internal  */
+    loadFromDataRecord(dr: TpActionDataRecord): boolean {
+        if (dr.rot)
+            this.rotate = evaluateValue(dr.rot);
+        if (dr.trsX)
+            this.translate = Point.new(evaluateValue(dr.trsX), evaluateValue(dr.trsY, null));
+        if (dr.sclX)
+            this.scale = Point.new(evaluateValue(dr.sclX), evaluateValue(dr.sclY, null));
+        if (dr.skwX)
+            this.skew = Point.new(evaluateValue(dr.skwX), evaluateValue(dr.skwY, null));
+        if (dr.order)
+            this.order = dr.order.split(', ') as TransformOpType[];
+        if (dr.scope)
+            this.scope = dr.scope;
         // console.dir(this);
+        return this.#cache.matrix == null;
+    }
+
+    /** @internal */
+    loadFromActionData(state: ParseState /* , statePrefix: string = Act.IconTx */): this {
+        // const dr = state.asRecord(state.pos, statePrefix + Str.IdSep);
+        this.loadFromDataRecord(state.dr);
         return this;
     }
 
-    /** Returns the current transform operations as a `DOMMatrix` which uses given `txOrigin` as origin point for rotatoin and scaling,
+    /** Returns the current transform operations as a `DOMMatrix` which uses given `txOrigin` as origin point for rotation and scaling,
         and scales translations to `txArea` size.  The returned value may be a cached version if no properties have changed since the cache was created,
         and `txOrigin` and `txArea` are the same as the cache'd version. Using this method with a new arguments will regenerate the matrix and update the cache. */
     getMatrix(txOrigin: PointType, txArea: SizeType) {
-        if (!this.cache.matrix || !this.cache.origin || !this.cache.size || !Point.fuzzyEquals(this.cache.origin, txOrigin) || !Size.fuzzyEquals(this.cache.size, txArea)) {
-            this.cache.matrix = this.toMatrix(txOrigin, txArea);
-            this.cache.origin = txOrigin;
-            this.cache.size = txArea;
+        if (!this.#cache.matrix || !this.#cache.origin || !this.#cache.size || !Point.fuzzyEquals(this.#cache.origin, txOrigin) || !Size.fuzzyEquals(this.#cache.size, txArea)) {
+            this.#cache.matrix = this.toMatrix(txOrigin, txArea);
+            this.#cache.origin = txOrigin;
+            this.#cache.size = txArea;
         }
-        return this.cache.matrix;
+        return this.#cache.matrix;
     }
 
-    /** Creates a DOMMatrix from the current transform options which uses given `txOrigin` as transform origin and scales translations to `txArea` size.
+    /** Creates a `DOMMatrix` from the current transform options which uses given `txOrigin` as transform origin and scales translations to `txArea` size.
         This method does not use any cached matrix but always generates a new one. */
     toMatrix(txOrigin: PointType, txArea: SizeType): DOMMatrix {
         const m = new DOMMatrix();
-        for (const op of this.transformOrder) {
+        for (const op of this.#transformOrder) {
             switch (op) {
                 case TransformOpType.Rotate:
-                    if (!fuzzyEquals4p(this.rotate, 0)) {
-                        // rotate from origin point
-                        m.translateSelf(txOrigin.x, txOrigin.y);
-                        m.rotateSelf(0, 0, round4p(this.rotate * .01 * 360));
-                        m.translateSelf(-txOrigin.x, -txOrigin.y);
-                    }
+                    if (!fuzzyEquals4p(this.#rotate, 0))
+                        m.rotateZSelf(round4p(this.#rotate * .01 * 360), txOrigin);
                     break;
                 case TransformOpType.Offset:
-                    if (!Point.fuzzyIsNull(this.translate))
-                        m.translateSelf(round4p(this.translate.x * .01 * txArea.width), round4p(this.translate.y * .01 * txArea.height), 0);
+                    if (!this.#translate.fuzzyIsNull)
+                        m.translateSelf(round4p(this.#translate.x * .01 * txArea.width), round4p(this.#translate.y * .01 * txArea.height), 0);
                     break;
                 case TransformOpType.Scale:
                     if (this.isScaling)
-                        m.scaleSelf(round4p(this.scale.x * .01), round4p(this.scale.y * .01), 0, txOrigin.x, txOrigin.y, 0);
+                        m.scaleSelf(round4p(this.#scale.x * .01), round4p(this.#scale.y * .01), 0, txOrigin.x, txOrigin.y, 0);
                     break;
                 case TransformOpType.Skew:
-                    if (!fuzzyEquals4p(this.skew.x, 0))
-                        m.skewXSelf(round4p(this.skew.x * .01));
-                    if (!fuzzyEquals4p(this.skew.y, 0))
-                        m.skewYSelf(round4p(this.skew.y * .01));
+                    if (!this.#skew.fuzzyIsNull)
+                        m.skewSelf(round4p(this.#skew.x * .01 * txArea.width), round4p(this.#skew.y * .01 * txArea.height), txOrigin);
                     break;
             }
         }
         return m;
     }
 
-    // ILayerElement
-    // Applies current transform matrix to the given canvas context using `rect` coordinates for tx center origin and area.
+    // IRenderable
+    /** Applies current transform matrix to the given canvas context using `rect` coordinates for tx center origin and area. */
     render(ctx: RenderContext2D, rect: Rectangle) : void {
          if (this.isEmpty)
             return;
 
         // For a cumulative ("everything above") type Tx we need to apply it to a new canvas/context and then afterwards we draw the original canvas on top.
-        if (this.scope == TransformScope.Cumulative) {
+        if (this.#scope == TransformScope.Cumulative) {
             // Here we need to copy anything drawn previously onto the new transformed context/canvas.
             // It may be clever to just switch up the context reference that is getting passed around
             // to all the render() methods... but that just seems wrong on several levels.
@@ -215,13 +228,17 @@ export default class Transformation implements ILayerElement, IRenderable
         }
     }
 
-    // IPathHandler
+    /** Applies current transform matrix to the given `paths` starting at `fromIdx` and using `rect.size` for relative scaling and translation.
+        The individual path bounds are used for computing center point for rotations and scaling.
+
+        If the `scope` of this transform is `TransformScope.PreviousOne` then only the last path in `paths` array is tranformed, regardless of how many there are in total.
+    */
     transformPaths(paths: Path2D[], _: RenderContext2D, rect: Rectangle, fromIdx: number = 0): void {
         const len = paths.length;
         if (!len || fromIdx < 0 || fromIdx >= len || this.isEmpty)
             return;
 
-        if (this.scope == TransformScope.PreviousOne)
+        if (this.#scope == TransformScope.PreviousOne)
             fromIdx = len - 1;
 
         for ( ; fromIdx < len; ++fromIdx) {

--- a/src/modules/elements/Transformation.ts
+++ b/src/modules/elements/Transformation.ts
@@ -1,9 +1,9 @@
 
-import { ILayerElement, IRenderable } from '../interfaces';
 import { Canvas, DOMMatrix, LayerRole, Point, Size, TransformOpType, Vect2d } from '../';
 import { DEFAULT_TRANSFORM_OP_ORDER } from '../../utils/consts';
 import { assignExistingProperties, arraysMatchExactly, evaluateValue, fuzzyEquals4p, round4p } from '../../utils';
-import type { ParseState, Path2D, PointType, Rectangle, RenderContext2D, SizeType, TpActionDataRecord } from '../';
+import type { ILayerElement, IRenderable } from '../interfaces';
+import type { ParseState, Path2D, Rectangle, } from '../';
 
 export const enum TransformScope {
     /** affects only the layer before the transform */

--- a/src/modules/elements/Transformation.ts
+++ b/src/modules/elements/Transformation.ts
@@ -43,7 +43,7 @@ export default class Transformation implements ILayerElement, IRenderable
         size: <SizeType | null> null,
     }
 
-    constructor(init?: Partial<Transformation>) {
+    constructor(init?: PartialDeep<Transformation>) {
         assignExistingProperties(this, init, 0);
     }
 

--- a/src/modules/elements/index.ts
+++ b/src/modules/elements/index.ts
@@ -9,7 +9,7 @@ export { default as DrawingStyle } from './DrawingStyle'
 export { default as DynamicImage } from './DynamicImage'
 export { default as EllipsePath } from './EllipsePath'              // inherits Path
 export { default as FreeformPath } from './FreeformPath'            // inherits Path
-export { default as LinearProgressBar } from './LinearProgressBar'  // inherits StyledRectangle
+export { default as LinearProgressBar, DrawDirection } from './LinearProgressBar'  // inherits StyledRectangle
 export { default as Path } from './Path'                            // inherits SizedElement
 export { default as RectanglePath } from './RectanglePath'          // inherits Path
 export { default as GaugeTicks } from './GaugeTicks'                // inherits SizedElement
@@ -21,5 +21,5 @@ export { default as ShadowStyle } from './ShadowStyle'
 export { default as SizedElement } from './SizedElement'
 export { default as StrokeStyle } from './StrokeStyle'
 export { default as StyledRectangle } from './StyledRectangle'      // inherits RectanglePath
-export { default as StyledText } from './StyledText'
+export { default as StyledText } from './StyledText'                // inherits SizedElement
 export { default as Transformation, TransformScope } from './Transformation'

--- a/src/modules/elements/index.ts
+++ b/src/modules/elements/index.ts
@@ -16,6 +16,7 @@ export { default as GaugeTicks } from './GaugeTicks'                // inherits 
 export { default as CircularTicks } from './CircularTicks'          // inherits GaugeTicks
 export { default as LinearTicks } from './LinearTicks'              // inherits GaugeTicks
 export { default as RoundProgressGauge } from './RoundProgressGauge'
+export { default as Script } from './Script'
 export { default as ShadowStyle } from './ShadowStyle'
 export { default as SizedElement } from './SizedElement'
 export { default as StrokeStyle } from './StrokeStyle'

--- a/src/modules/elements/index.ts
+++ b/src/modules/elements/index.ts
@@ -12,6 +12,9 @@ export { default as FreeformPath } from './FreeformPath'            // inherits 
 export { default as LinearProgressBar } from './LinearProgressBar'  // inherits StyledRectangle
 export { default as Path } from './Path'                            // inherits SizedElement
 export { default as RectanglePath } from './RectanglePath'          // inherits Path
+export { default as GaugeTicks } from './GaugeTicks'                // inherits SizedElement
+export { default as CircularTicks } from './CircularTicks'          // inherits GaugeTicks
+export { default as LinearTicks } from './LinearTicks'              // inherits GaugeTicks
 export { default as RoundProgressGauge } from './RoundProgressGauge'
 export { default as ShadowStyle } from './ShadowStyle'
 export { default as SizedElement } from './SizedElement'

--- a/src/modules/elements/index.ts
+++ b/src/modules/elements/index.ts
@@ -3,7 +3,7 @@
 export { default as BarGraph } from './BarGraph'
 export { default as BrushStyle } from './BrushStyle'
 export { default as CanvasFilter } from './CanvasFilter'
-export { default as ClippingMask } from './ClippingMask'
+export { default as ClippingMask, ClipAction } from './ClippingMask'
 export { default as CompositionMode } from './CompositionMode'
 export { default as DrawingStyle } from './DrawingStyle'
 export { default as DynamicImage } from './DynamicImage'

--- a/src/modules/enums.ts
+++ b/src/modules/enums.ts
@@ -1,4 +1,5 @@
 
+/** @internal */
 export const enum LayerRole {
     None         = 0,
     Drawable     = 0x01,
@@ -7,31 +8,51 @@ export const enum LayerRole {
     PathConsumer = 0x08,
 }
 
+/** Describes the orientation of a linear element. */
 export const enum Orientation { H, V };
 
+/** Describes the drawing direction for a circular path (arc, ellipse, etc). `Auto` value meaning depends on implementation. */
 export const enum ArcDrawDirection { CW, CCW, Auto }
 
+/** Describes the location of an element in relation to another. */
 export const enum Placement {
     NoPlace, Inside, Outside, Center,
     TopLeft = Inside,
     BottomRight = Outside,
 }
 
+/** Describes horizontal and vertical alignment values. */
 export const enum Alignment {
     NONE     = 0,
+    // horizontal
     LEFT     = 0x01,
     RIGHT    = 0x02,
     HCENTER  = 0x04,
     JUSTIFY  = 0x08,
+    H_MASK   = 0x0F,  // mask
+    // vertical
     TOP      = 0x10,
     BOTTOM   = 0x20,
     VCENTER  = 0x40,
     BASELINE = 0x80,
-    CENTER   = VCENTER | HCENTER,
-    H_MASK   = LEFT | RIGHT | HCENTER | JUSTIFY,
-    V_MASK   = TOP | BOTTOM | VCENTER | BASELINE,
+    V_MASK   = 0xF0,  // mask
+    // aliases
+    CENTER    = VCENTER | HCENTER,
+    TopLeft   = TOP | LEFT,
+    TopCenter = TOP | HCENTER,
+    TopCtr    = TopCenter,
+    TopRight  = TOP | RIGHT,
+    MidLeft   = VCENTER | LEFT,
+    MidCenter = VCENTER | HCENTER,
+    MidCtr    = MidCenter,
+    MidRight  = VCENTER | RIGHT,
+    BotLeft   = BOTTOM | LEFT,
+    BotCenter = BOTTOM | HCENTER,
+    BotCtr    = BotCenter,
+    BotRight  = BOTTOM | RIGHT,
 };
 
+/** Path combining operations for {@link Path} type and subclasses. */
 export const enum PathBoolOperation {
     None       = "none",
     Add        = "add",  // actually `addPath()`
@@ -42,6 +63,7 @@ export const enum PathBoolOperation {
     Xor        = "xor"
 }
 
+/** Transformation operation type, used by {@link Transformation }. */
 export const enum TransformOpType {
     Offset = 'O',
     Rotate = 'R',
@@ -49,6 +71,9 @@ export const enum TransformOpType {
     Skew = 'SK',
 }
 
+/** Used by elements supporting the `setColor(value: string, type: ColorUpdateType)` method (`IColorElement` interface).
+    @internal
+*/
 export const enum ColorUpdateType {
     None      = 0,
     Stroke    = 0x01,

--- a/src/modules/enums.ts
+++ b/src/modules/enums.ts
@@ -9,6 +9,8 @@ export const enum LayerRole {
 
 export const enum Orientation { H, V };
 
+export const enum ArcDrawDirection { CW, CCW, Auto }
+
 export const enum Alignment {
     NONE     = 0,
     LEFT     = 0x01,

--- a/src/modules/enums.ts
+++ b/src/modules/enums.ts
@@ -11,6 +11,12 @@ export const enum Orientation { H, V };
 
 export const enum ArcDrawDirection { CW, CCW, Auto }
 
+export const enum Placement {
+    NoPlace, Inside, Outside, Center,
+    TopLeft = Inside,
+    BottomRight = Outside,
+}
+
 export const enum Alignment {
     NONE     = 0,
     LEFT     = 0x01,
@@ -43,7 +49,6 @@ export const enum TransformOpType {
     Skew = 'SK',
 }
 
-// Flags type for possible future use. No element currently supports setting multple properties at once.
 export const enum ColorUpdateType {
     None      = 0,
     Stroke    = 0x01,

--- a/src/modules/geometry/Rectangle.ts
+++ b/src/modules/geometry/Rectangle.ts
@@ -1,33 +1,59 @@
 import { PointType, Point, Size, SizeType, Vect2d } from './';
 import { round5p } from '../../utils';
 
+/** A rectangle type storing x, y, with, & height values. Convenience methods are provided for various operations.
+
+The values are stored as `origin` (`Vect2d` type) and `size` (`Size` type) properties
+which can be read or manipulated directly using their respective methods.
+*/
 export default class Rectangle
 {
-    origin: Vect2d = new Vect2d();
-    size: Size =  new Size();
+    readonly origin: Vect2d = new Vect2d();
+    readonly size: Size =  new Size();
 
     constructor();
+    constructor(rect: Rectangle);
     constructor(origin: PointType, size: SizeType);
     constructor(origin: PointType, width: number, height: number);
     constructor(top: number, left: number, size: SizeType);
     constructor(top: number, left: number, width: number, height: number);
     // implementation
-    constructor(xOrOrigin?: number | PointType, yOrWorSize?: number | SizeType, wOrHorSize?: number | SizeType, h?: number) {
-        if (xOrOrigin == undefined)
-            return;
-        if (typeof xOrOrigin == "object")
-            Point.set(this.origin, xOrOrigin);
-        else
-            Point.set(this.origin, xOrOrigin, (typeof yOrWorSize == "number" ? yOrWorSize : undefined));
+    constructor(...args: any[]) {
+        // @ts-ignore
+        this.set(...args);
+    }
 
-        if (typeof (yOrWorSize) === "object")
-            Size.set(this.size, yOrWorSize.width, yOrWorSize.height);
-        else if (typeof (wOrHorSize) === "object")
-            Size.set(this.size, wOrHorSize.width, wOrHorSize.height);
-        else if (typeof yOrWorSize == 'number' && typeof xOrOrigin == "object")
-            Size.set(this.size, yOrWorSize, wOrHorSize);
-        else if (wOrHorSize != undefined)
-            Size.set(this.size, wOrHorSize, h);
+    set(rect: Rectangle): this;
+    set(origin: PointType, size: SizeType): this;
+    set(origin: PointType, width: number, height: number): this;
+    set(top: number, left: number, size: SizeType): this;
+    set(top: number, left: number, width: number, height: number): this;
+    // implementation
+    set(...args: any[]): this {
+        // (0?: number | PointType | Rectangle, 1?: number | SizeType, 2?: number | SizeType, 3?: number)
+        if (args[0] == undefined)
+            return this;
+        let arg0isObj = (typeof args[0] == 'object'),
+            arg1notObj = false;
+        if (arg0isObj) {
+            if (args[0] instanceof Rectangle)
+                return this.set(args[0].origin, args[0].size);
+            Point.set(this.origin, args[0]);
+        }
+        else if (typeof args[0] == 'number') {
+            Point.set(this.origin, args[0], args[1]);
+            arg1notObj = true;
+        }
+
+        if (!arg1notObj && typeof args[1] == 'object')
+            return this.setSize(args[1]);
+         if (arg1notObj && typeof args[2] == 'object')
+            return this.setSize(args[2]);
+        if (typeof args[1] == 'number' && arg0isObj)
+            return this.setSize(args[1], args[2]);
+        if (args[2] != undefined)
+            return this.setSize(args[2], args[3]);
+        return this;
     }
 
     clone(): Rectangle {
@@ -44,7 +70,7 @@ export default class Rectangle
     }
     /** Creates a new instance of Rectangle from a "bounds" type object where origin coordinate properties are left/top instead of x/y. */
     static fromBounds(bounds: {left: number, top: number, width: number, height: number}): Rectangle {
-        return new Rectangle(Point.new(bounds.left, bounds.top), Size.new(bounds.width, bounds.height));
+        return new Rectangle(bounds.left, bounds.top, bounds.width, bounds.height);
     }
 
     get x(): number  { return this.origin.x; }
@@ -107,8 +133,9 @@ export default class Rectangle
     /** Adds given offsets to a copy of this rectangle and returns the copy. */
     adjusted(left: number, top: number, right: number, bottom: number): Rectangle;
     // implementation
-    adjusted(leftOrOffs: number | PointType, topOrRtOrSz: number | SizeType, rtOrBot?: number, bottom?: number): Rectangle {
-        return Rectangle.adjust(this.clone(), leftOrOffs, topOrRtOrSz, rtOrBot, bottom);
+    adjusted(...args: any[]): Rectangle {
+        // @ts-ignore
+        return Rectangle.adjust(this.clone(), ...args);
     }
 
     /** Adds `origin` to both origin coordinates and `size` to both size coordinates of this instance and returns itself. */
@@ -118,8 +145,9 @@ export default class Rectangle
     /** Adds given values to this rectangle's coordinates and returns this instance. */
     adjust(left: number, top: number, right: number, bottom: number): this;
     // implementation
-    adjust(leftOrOffs: number | PointType, topOrOrSz: number | SizeType, rtOrBot?: number, bottom?: number): this {
-        return Rectangle.adjust(this, leftOrOffs, topOrOrSz, rtOrBot, bottom) as this;
+    adjust(...args: any[]): this {
+        // @ts-ignore
+        return Rectangle.adjust(this, ...args) as this;
     }
 
     /** Moves the x,y origin of the rectangle by the given offset. */
@@ -139,8 +167,9 @@ export default class Rectangle
     /** Adds given offsets to a copy of `rect` Rectangle and returns the copy. */
     static adjusted(rect: Rectangle, left: number, top: number, right: number, bottom: number): Rectangle;
     // implementation
-    static adjusted(rect: Rectangle, leftOrOffs: number | PointType, topOrSz: number | SizeType, rtOrBot?: number, bottom?: number): Rectangle {
-        return Rectangle.adjust(rect.clone(), leftOrOffs, topOrSz, rtOrBot, bottom);
+    static adjusted(...args: any[]): Rectangle {
+        // @ts-ignore
+        return Rectangle.adjust(rect.clone(), ...args);
     }
 
     /** Adds `origin` to both `rect.origin` coordinates and `size` to both `rect.size` coordinates. The input rectangle is modified. Returns the adjusted Rectangle.  */
@@ -149,8 +178,6 @@ export default class Rectangle
     static adjust(rect: Rectangle, origin: number | PointType, right: number, bottom: number): Rectangle;
     /** Adds given offsets to the given rectangle's coordinates. The input rectangle is modified. Returns the adjusted Rectangle. */
     static adjust(rect: Rectangle, left: number, top: number, right: number, bottom: number): Rectangle;
-    /** This overload is for internal use; one of the other overloads will be invoked in most cases. */
-    static adjust(rect: Rectangle, leftOrOffs: number | PointType, topOrSz: number | SizeType, rtOrBot?: number, bottom?: number): Rectangle;
     // implementation
     static adjust(
         rect: Rectangle,

--- a/src/modules/geometry/Rectangle.ts
+++ b/src/modules/geometry/Rectangle.ts
@@ -12,22 +12,22 @@ export default class Rectangle
     constructor(top: number, left: number, size: SizeType);
     constructor(top: number, left: number, width: number, height: number);
     // implementation
-    constructor(xOrOrigin?: number | PointType, yOrSize?: number | SizeType, wOrSize?: number | SizeType, h?: number) {
+    constructor(xOrOrigin?: number | PointType, yOrWorSize?: number | SizeType, wOrHorSize?: number | SizeType, h?: number) {
         if (xOrOrigin == undefined)
             return;
         if (typeof xOrOrigin == "object")
             Point.set(this.origin, xOrOrigin);
         else
-            Point.set(this.origin, xOrOrigin, (typeof yOrSize == "number" ? yOrSize : undefined));
+            Point.set(this.origin, xOrOrigin, (typeof yOrWorSize == "number" ? yOrWorSize : undefined));
 
-        if (typeof (yOrSize) === "object")
-            Size.set(this.size, yOrSize.width, yOrSize.height);
-        else if (wOrSize == undefined)
-            return;
-        else if (typeof (wOrSize) === "object")
-            Size.set(this.size, wOrSize.width, wOrSize.height);
-        else
-            Size.set(this.size, wOrSize, h);
+        if (typeof (yOrWorSize) === "object")
+            Size.set(this.size, yOrWorSize.width, yOrWorSize.height);
+        else if (typeof (wOrHorSize) === "object")
+            Size.set(this.size, wOrHorSize.width, wOrHorSize.height);
+        else if (typeof yOrWorSize == 'number' && typeof xOrOrigin == "object")
+            Size.set(this.size, yOrWorSize, wOrHorSize);
+        else if (wOrHorSize != undefined)
+            Size.set(this.size, wOrHorSize, h);
     }
 
     clone(): Rectangle {
@@ -40,7 +40,7 @@ export default class Rectangle
 
     /** Creates a new instance of Rectangle with origin(0,0) and the given size for width and height. */
     static fromSize(size: SizeType): Rectangle {
-        return new Rectangle(0, 0, size.width, size.height);
+        return new Rectangle(Point.new(), size);
     }
     /** Creates a new instance of Rectangle from a "bounds" type object where origin coordinate properties are left/top instead of x/y. */
     static fromBounds(bounds: {left: number, top: number, width: number, height: number}): Rectangle {
@@ -69,6 +69,28 @@ export default class Rectangle
     /** Returns true if both width and height values are equal to zero to within 4 decimal places of precision. */
     get fuzzyIsNull() { return this.size.fuzzyIsNull; }
 
+    /** Sets the top left coordinates of this rectangle to `origin` and returns itself. */
+    setOrigin(origin: PointType): this;
+    /** Sets the top left coordinates of this rectangle to `x` and `y` and returns itself.
+        If `y` is undefined then value of `x` is used for both dimensions. */
+    setOrigin(x: number, y?: number): this;
+    // implementation
+    setOrigin(xOrOrigin: number | PointType, y?: number): this {
+        this.origin.set(xOrOrigin, y);
+        return this;
+    }
+
+    /** Sets the size of this rectangle to `size` and returns itself. */
+    setSize(size: SizeType): this;
+    /** Sets the size of this rectangle to `width` and `height` and returns itself.
+        If `height` is undefined then value of `width` is used for both dimensions. */
+    setSize(width: number, height?: number): this;
+    // implementation
+    setSize(widthOrSize: number | SizeType, height?: number): this {
+        this.size.set(widthOrSize, height);
+        return this;
+    }
+
     /** Returns true if this rectangle's origin and size are equal to `other` rectangle's origin and size. */
     equals(other: Rectangle): boolean {
         return this.origin.equals(other.origin) && this.size.equals(other.size);
@@ -90,14 +112,24 @@ export default class Rectangle
     }
 
     /** Adds `origin` to both origin coordinates and `size` to both size coordinates of this instance and returns itself. */
-    adjust(origin: number | PointType, size: number | SizeType): Rectangle;
+    adjust(origin: number | PointType, size: number | SizeType): this;
     /** Adds `origin` to both origin coordinates and `right` and `bottom` to size coordinates of this instance and returns itself. */
-    adjust(origin: number | PointType, right: number, bottom: number): Rectangle;
+    adjust(origin: number | PointType, right: number, bottom: number): this;
     /** Adds given values to this rectangle's coordinates and returns this instance. */
-    adjust(left: number, top: number, right: number, bottom: number): Rectangle;
+    adjust(left: number, top: number, right: number, bottom: number): this;
     // implementation
-    adjust(leftOrOffs: number | PointType, topOrOrSz: number | SizeType, rtOrBot?: number, bottom?: number): Rectangle {
-        return Rectangle.adjust(this, leftOrOffs, topOrOrSz, rtOrBot, bottom);
+    adjust(leftOrOffs: number | PointType, topOrOrSz: number | SizeType, rtOrBot?: number, bottom?: number): this {
+        return Rectangle.adjust(this, leftOrOffs, topOrOrSz, rtOrBot, bottom) as this;
+    }
+
+    /** Moves the x,y origin of the rectangle by the given offset. */
+    translate(offset: PointType): this
+    /** Moves the x,y origin of the rectangle by the given amounts. If `y` is undefined then `x` value is added to both dimensions. */
+    translate(x: number, y?: number): this;
+    // implementation
+    translate(xOrOffs: number | PointType, y?: number): this {
+        this.origin.plus_eq(xOrOffs, y);
+        return this;
     }
 
     /** Adds given offsets to a copy of the `rect` Rectangle and returns the copied & adjusted Rectangle. */

--- a/src/modules/geometry/Rectangle.ts
+++ b/src/modules/geometry/Rectangle.ts
@@ -15,8 +15,8 @@ export default class Rectangle
     constructor(rect: Rectangle);
     constructor(origin: PointType, size: SizeType);
     constructor(origin: PointType, width: number, height: number);
-    constructor(top: number, left?: number, size?: SizeType);
-    constructor(top: number, left: number, width?: number, height?: number);
+    constructor(x: number, y: number, size?: SizeType);
+    constructor(x?: number, y?: number, width?: number, height?: number);
     // implementation
     constructor(...args: any[]) {
         // @ts-ignore
@@ -26,8 +26,8 @@ export default class Rectangle
     set(rect: Rectangle): this;
     set(origin: PointType, size?: SizeType): this;
     set(origin: PointType, width?: number, height?: number): this;
-    set(top: number, left: number, size?: SizeType): this;
-    set(top?: number, left?: number, width?: number, height?: number): this;
+    set(x: number,  y: number, size?: SizeType): this;
+    set(x?: number, y?: number, width?: number, height?: number): this;
     // implementation
     set(...args: any[]): this {
         // (0?: number | PointType | Rectangle, 1?: number | SizeType, 2?: number | SizeType, 3?: number)

--- a/src/modules/geometry/Rectangle.ts
+++ b/src/modules/geometry/Rectangle.ts
@@ -61,7 +61,7 @@ export default class Rectangle
     }
 
     toString(): string {
-        return `${this.constructor.name}(${this.x},${this.y} ${this.width}x${this.height}; L:${this.left} R:${this.right} T:${this.top} B:${this.bottom})`;
+        return `${this.constructor.name}(\n\tx: ${this.x} y: ${this.y} width: ${this.width} height: ${this.height}\n\tleft: ${this.left} right: ${this.right} top: ${this.top} bot: ${this.bottom} ctr: ${this.center.x},${this.center.y}\n)`;
     }
 
     /** Creates a new instance of Rectangle with origin(0,0) and the given size for width and height. */

--- a/src/modules/geometry/Size.ts
+++ b/src/modules/geometry/Size.ts
@@ -1,10 +1,13 @@
 import { fuzzyEquals } from "../../utils";
+import type { PointType } from "..";
 
 export type SizeType = {
     width: number;
     height: number;
 }
-
+/** The `Size` class represents an object with `width` and `height` properties. Convenience properties and methods are provided for various operations.
+It also provides static methods for working with any `SizeType` object (anything with `width` and `height` properties).
+*/
 export class Size implements SizeType
 {
     width: number = 0;
@@ -34,6 +37,20 @@ export class Size implements SizeType
     equals(widthOrSize: number | SizeType, height?: number): boolean { return Size.equals(this, widthOrSize, height); }
     /** Returns true is this size equals the given SizeType to within `epsilon` decimal places of precision. */
     fuzzyEquals(other: SizeType, epsilon: number = 0.0001): boolean { return Size.fuzzyEquals(this, other, epsilon); }
+
+    /** Adds value(s) to current coordinates. Modifies the current value of this instance and returns itself */
+    plus_eq(widthOrSize: number | SizeType | PointType, height?: number): this { return Size.plus_eq(this, widthOrSize, height) as this; }
+    /** Adds value(s) to current coordinates and returns a new Vect2d object. */
+    plus(widthOrSize: number | SizeType | PointType, height?: number): Size { return Size.plus_eq(this.clone(), widthOrSize, height) as Size; }
+    /** Adds value(s) to `size` and returns new instance, does not modify input value. */
+    static add(size: Size, widthOrSize: number | SizeType | PointType, height?: number): Size { return size.clone().plus_eq(widthOrSize, height); }
+
+    /** Multiplies current coordinates by value(s). Modifies the current value of this instance and returns itself */
+    times_eq(widthOrSize: number | SizeType | PointType, height?: number): this { return Size.times_eq(this, widthOrSize, height) as this; }
+    /** Multiplies current coordinates by value(s) and returns a new `Vect2d` object. */
+    times(widthOrSize: number | SizeType | PointType, height?: number): Size { return Size.times_eq(this.clone(), widthOrSize, height) as Size; }
+    /** Multiplies `size` coordinates by value(s) and returns new instance, does not modify input value, */
+    static multiply(size: Size, widthOrSize: number | SizeType | PointType, height?: number): Size { return Size.times_eq(size.clone(), widthOrSize, height) as Size; }
 
     toString() { Size.toString(this); }
 
@@ -82,6 +99,40 @@ export class Size implements SizeType
     static fuzzyEquals(sz: SizeType, other: SizeType, epsilon: number = 0.0001): boolean {
         return fuzzyEquals(other.width, sz.width, epsilon) && fuzzyEquals(other.height, sz.height, epsilon);
     }
+
+
+    /** Adds value(s) to `sz` and returns it. Modifies input value. */
+    static plus_eq(sz: SizeType, widthOrSize: number | SizeType | PointType, height?: number): SizeType {
+        if (typeof widthOrSize == "number")
+            return Size.set(sz, sz.width + widthOrSize, sz.height + (height == undefined ? widthOrSize : height));
+        if (typeof widthOrSize != 'object')
+            return sz;
+        if ('width' in widthOrSize)
+            return Size.set(sz, sz.width + widthOrSize.width, sz.height + widthOrSize.height);
+        return Size.set(sz, sz.width + widthOrSize.x, sz.height + widthOrSize.y);
+    }
+
+    /** Adds value(s) to `sz` and returns new instance, does not modify input value. */
+    static plus(sz: SizeType, widthOrSize: number | SizeType | PointType, height?: number): SizeType {
+        return Size.plus_eq(Size.new(sz), widthOrSize, height);
+    }
+
+    /** Multiplies `sz` coordinates by value(s) and returns it. Modifies input value. */
+    static times_eq(sz: SizeType, widthOrSize: number | SizeType | PointType, height?: number): SizeType {
+        if (typeof widthOrSize == "number")
+            return Size.set(sz, sz.width * widthOrSize, sz.height * (height == undefined ? widthOrSize : height));
+        if (typeof widthOrSize != 'object')
+            return sz;
+        if ('width' in widthOrSize)
+            return Size.set(sz, sz.width * widthOrSize.width, sz.height * widthOrSize.height);
+        return Size.set(sz, sz.width * widthOrSize.x, sz.height * widthOrSize.y);
+    }
+
+    /** Multiplies `sz` coordinates by value(s) and returns new instance, does not modify input value, */
+    static times(sz: SizeType, widthOrSize: number | SizeType | PointType, height?: number): SizeType {
+        return Size.times_eq(Size.new(sz), widthOrSize, height);
+    }
+
 
     static toString(sz: SizeType, name: string = "Size"): string {
         return `${name}{w: ${sz.width}, h:${sz.height}}`;

--- a/src/modules/geometry/Size.ts
+++ b/src/modules/geometry/Size.ts
@@ -21,18 +21,21 @@ export class Size implements SizeType
     /** Returns true if both width and height values are equal to zero to within 4 decimal places of precision. */
     get fuzzyIsNull(): boolean { return Size.fuzzyIsNull(this, 0.0001); }
 
+    /** Returns a new `Size` instance with values copied from this one. */
+    clone() : Size { return new Size(this); }
+
     /** Set the width and height properties.
         The `widthOrSize` parameter can be any object containing 'width' and 'height' properties, or a numeric value for the 'width' value.
         In the latter case, if a `height` parameter is passed, it is assigned to the 'height' value; otherwise the `widthOrSize` parameter
         is used for both 'width' and 'height'.  */
-    set(widthOrSize: number | SizeType = 0, height?: number): Size { return Size.set(this, widthOrSize, height) as Size; }
-
-    toString() { Size.toString(this); }
+    set(widthOrSize: number | SizeType = 0, height?: number): this { return Size.set(this, widthOrSize, height) as this; }
 
     /** Returns true if this size equals the `widthOrSize` SizeType or width & height values. */
     equals(widthOrSize: number | SizeType, height?: number): boolean { return Size.equals(this, widthOrSize, height); }
     /** Returns true is this size equals the given SizeType to within `epsilon` decimal places of precision. */
     fuzzyEquals(other: SizeType, epsilon: number = 0.0001): boolean { return Size.fuzzyEquals(this, other, epsilon); }
+
+    toString() { Size.toString(this); }
 
     // Static methods operate only on generic `SizeType` types, not `Size`.
     // This is generally faster for creation and read-only access than an full new instance of `Size`, but slower for writes/updates.

--- a/src/modules/geometry/UnitValue.ts
+++ b/src/modules/geometry/UnitValue.ts
@@ -2,7 +2,7 @@
     For now unit types are only "%" or "px", and this object just stores
     a flag indicating if the value is relative (%) or absolute (px).
 */
-export default class UnitValue {
+export default class UnitValue extends Object {
     value: number;
     isRelative!: boolean;
     unit!: string;
@@ -11,6 +11,7 @@ export default class UnitValue {
     constructor(value: number, unit: string);
     constructor(value: number, isRelative: boolean);
     constructor(value: number = 0, unit: any = false) {
+        super();
         this.value = value;
         if (unit.length)
             this.setUnit(unit);
@@ -31,6 +32,10 @@ export default class UnitValue {
     setRelative(relative: boolean) {
         this.isRelative = relative;
         this.unit = relative ? "%" : "px";
+    }
+
+    override toString(): string {
+        return this.value + this.unit;
     }
 
 }

--- a/src/modules/geometry/UnitValue.ts
+++ b/src/modules/geometry/UnitValue.ts
@@ -51,7 +51,7 @@ export default class UnitValue extends Object {
         let v:any = parseFloat(value);
         if (v != Number.NaN)
             this.value = v;
-        v = value.replace(/\W/g, '');
+        v = value.replace(/[\W\d]/g, '');
         if (v)
             this.setUnit(v);
         return this;

--- a/src/modules/geometry/UnitValue.ts
+++ b/src/modules/geometry/UnitValue.ts
@@ -3,24 +3,34 @@
     a flag indicating if the value is relative (%) or absolute (px).
 */
 export default class UnitValue extends Object {
-    value: number;
-    isRelative!: boolean;
+    value: number = 0;
+    isRelative: boolean = false;
     unit!: string;
 
     constructor(value?: number);
+    constructor(value: string);
     constructor(value: number, unit: string);
     constructor(value: number, isRelative: boolean);
-    constructor(value: number = 0, unit: any = false) {
+    constructor(value: number | string = 0, unit: any = false) {
         super();
-        this.value = value;
-        if (unit.length)
-            this.setUnit(unit);
-        else
-            this.setRelative(unit);
+        if (typeof value == 'number') {
+            this.value = value;
+            if (unit.length)
+                this.setUnit(unit);
+            else
+                this.setRelative(unit);
+            return;
+        }
+        if (typeof value == 'string')
+            this.setFromString(value);
     }
 
     static isRelativeUnit(unit: string) {
         return unit === "%";
+    }
+
+    static fromString(value: string): UnitValue {
+        return new UnitValue().setFromString(value);
     }
 
     setUnit(unit: string): boolean {
@@ -32,6 +42,16 @@ export default class UnitValue extends Object {
     setRelative(relative: boolean) {
         this.isRelative = relative;
         this.unit = relative ? "%" : "px";
+    }
+
+    setFromString(value: string) {
+        let v:any = parseInt(value);
+        if (v != Number.NaN)
+            this.value = v;
+        v = value.replace(/\D/, '');
+        if (v)
+            this.setUnit(v);
+        return this;
     }
 
     override toString(): string {

--- a/src/modules/geometry/UnitValue.ts
+++ b/src/modules/geometry/UnitValue.ts
@@ -5,7 +5,7 @@
 export default class UnitValue extends Object {
     value: number = 0;
     isRelative: boolean = false;
-    unit!: string;
+    protected _unit!: string;
 
     constructor(value?: number);
     constructor(value: string);
@@ -33,29 +33,32 @@ export default class UnitValue extends Object {
         return new UnitValue().setFromString(value);
     }
 
+    get unit() { return this._unit; }
+    set unit(unit: string) { this.setUnit(unit); }
+
     setUnit(unit: string): boolean {
         this.isRelative = UnitValue.isRelativeUnit(unit);
-        this.unit = unit;
+        this._unit = unit;
         return this.isRelative;
     }
 
     setRelative(relative: boolean) {
         this.isRelative = relative;
-        this.unit = relative ? "%" : "px";
+        this._unit = relative ? "%" : "px";
     }
 
     setFromString(value: string) {
-        let v:any = parseInt(value);
+        let v:any = parseFloat(value);
         if (v != Number.NaN)
             this.value = v;
-        v = value.replace(/\D/, '');
+        v = value.replace(/\W/g, '');
         if (v)
             this.setUnit(v);
         return this;
     }
 
     override toString(): string {
-        return this.value + this.unit;
+        return this.value + this._unit;
     }
 
 }

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -1,33 +1,36 @@
 
 import type { ColorUpdateType, LayerRole, ParseState, Path2D, Rectangle, RenderContext2D } from './';
 
-// DynamicIcon uses this type for its layers array members.
+/** Represents an element of a dynamic image. `DynamicIcon` uses this type for its layers array members. */
 export interface ILayerElement {
-    readonly type: string;
+    /** @internal */
     readonly layerRole?: LayerRole;
+    /** @internal */
     loadFromActionData(state: ParseState) : ILayerElement
  }
 
-// Represents an abstract item which can be drawn onto, or otherwise affect (eg. style, transform), a canvas context.
+/** Represents an abstract item which can be drawn onto, or otherwise affect (eg. style, transform), a canvas context. */
 export interface IRenderable extends ILayerElement {
     render(context: RenderContext2D, rect?:Rectangle): Promise<void> | void;
 }
 
+/** An element interface which produces a Path2D type object which can then be used for styling, clipping, etc. */
 export interface IPathProducer extends ILayerElement {
     getPath(rect?: Rectangle, pathStack?: Array<Path2D>) : Path2D;
 }
 
+/** An element interface which "consumes" Path2D objects, for example to apply a drawing style or use as a clipping mask. */
 export interface IPathHandler extends ILayerElement {
     renderPaths(paths: Array<Path2D>, context?: RenderContext2D, rect?: Rectangle) : void;
 }
 
-// An interface with a "setValue()" method. Elements which can reflect value(s) can implement this to update data w/out re-creating the element.
-// Really this is just to make TypeScript compiler happy... to check if an element "implements the interface" we have to check for existence/type of "setValue" property anyway.
+/** An interface with a "setValue()" method. Elements which can reflect value(s) can implement this to update data w/out re-parsing other action data.
+    Really this is just to make TypeScript compiler happy... to check if an element "implements the interface" we have to check for existence/type of "setValue" property anyway. */
 export interface IValuedElement extends ILayerElement {
     setValue(value: string): void;
 }
 
-// An interface with a "setColor()" method. Elements which use colors can implement this to update color values w/out re-creating the element.
+/** An interface with a "setColor()" method. Elements which use colors can implement this to update color values w/out re-parsing other action data. */
 export interface IColorElement extends ILayerElement {
     setColor(value: string, type: ColorUpdateType): void;
 }

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -4,7 +4,7 @@ import type { ColorUpdateType, LayerRole, ParseState, Path2D, Rectangle, RenderC
 /** Represents an element of a dynamic image. `DynamicIcon` uses this type for its layers array members. */
 export interface ILayerElement {
     /** @internal */
-    readonly layerRole?: LayerRole;
+    readonly layerRole: LayerRole;
     /** @internal */
     loadFromActionData(state: ParseState) : ILayerElement
  }

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -1,12 +1,11 @@
 
-import { ColorUpdateType, LayerRole } from './enums';
-import { Rectangle } from './geometry';
-import { Path2D, RenderContext2D } from './types';
+import type { ColorUpdateType, LayerRole, ParseState, Path2D, Rectangle, RenderContext2D } from './';
 
 // DynamicIcon uses this type for its layers array members.
 export interface ILayerElement {
     readonly type: string;
     readonly layerRole?: LayerRole;
+    loadFromActionData(state: ParseState) : ILayerElement
  }
 
 // Represents an abstract item which can be drawn onto, or otherwise affect (eg. style, transform), a canvas context.

--- a/src/modules/logging/Logger.ts
+++ b/src/modules/logging/Logger.ts
@@ -51,7 +51,7 @@ export default class Logger
         this.minLevel = minLevel;
     }
 
-    private async log_impl(logLevel: LogLevel, message: any, ...args: any[]): Promise<void>
+    private log_impl(logLevel: LogLevel, message: any, ...args: any[])
     {
         if (logLevel < this.minLevel)
             return;
@@ -65,7 +65,7 @@ export default class Logger
         };
 
         // This creates a new stack trace and pulls the caller from it.
-        if (logLevel < LogLevel.INFO) {
+        if (logLevel < LogLevel.INFO || logLevel > LogLevel.WARNING) {
             const error:any = {};
             // The stack trace will start at the function _before_ this one. Since all the public log functions
             // are proxies for this one, we know they're the next ones up the stack and the one before that will be the caller.

--- a/src/modules/logging/StreamEndpoint.ts
+++ b/src/modules/logging/StreamEndpoint.ts
@@ -100,7 +100,7 @@ export default class StreamEndpoint implements ILogEndpoint
     get minLevel(): LogLevel { return this.level; }
     set minLevel(level: LogLevel) { this.options.minLevel = this.level = level; }
 
-    async logEntry(entry: ILogEntry)
+    logEntry(entry: ILogEntry)
     {
         if (!this.cnsl || entry.level < this.level)
             return;

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -3,6 +3,8 @@ export type TpActionDataType = { id:string, value:string };
 export type TpActionDataArrayType = TpActionDataType[];
 export type TpActionDataRecord = Record<string, string>;
 
+export type ConstructorType<T> = new(...args:any[])=>T;
+
 // We specifically need the CanvasRenderingContext2D and Path2D from Skia, not the default definitions, since they have methods we use which the default versions doesn't.
 // The idea is to centralize the types here which other modules need, instead of importing from skia-canvas inside each implementation.
 // This should also make is easier to change provider libraries if necessary.

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -76,5 +76,3 @@ declare global {
 
 // TODO: Update all code to rely on global declarations and remove these. Maybe declare creatable canvas/geo types as global also?
 export type RenderContext2D = canvas.CanvasRenderingContext2D;
-/** @internal */
-export type TpActionDataRecord = globalThis.TpActionDataRecord;

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -12,11 +12,14 @@ export type ConstructorType<T> = new(...args:any[])=>T;
 /** Defines how to resize images (or other block elements). Equivalent to CSS `object-fit` property. */
 export type ResizeFitOption = "contain" | "cover" | "fill" | "scale-down" | "none";
 
+import type { CanvasGradient, CanvasPattern, CanvasTexture } from 'skia-canvas';
+export type ContextFillStrokeType = string | CanvasGradient | CanvasPattern | CanvasTexture;
+
 // We specifically need the CanvasRenderingContext2D and Path2D from Skia, not the default definitions, since they have methods we use which the default versions doesn't.
 // The idea is to centralize the types here which other modules need, instead of importing from skia-canvas inside each implementation.
 // This should also make is easier to change provider libraries if necessary.
 export {
-    Canvas, CanvasRenderingContext2D,
+    Canvas, CanvasGradient, CanvasPattern, CanvasRenderingContext2D, CanvasTexture,
     DOMMatrix, DOMPoint, DOMRect,
     Image, ImageData, loadImage, loadImageData,
     Path2D, TextMetrics,

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -1,16 +1,24 @@
 
+/** @internal */
 export type TpActionDataType = { id:string, value:string };
+/** @internal */
 export type TpActionDataArrayType = TpActionDataType[];
+/** @internal */
 export type TpActionDataRecord = Record<string, string>;
 
+/** @internal */
 export type ConstructorType<T> = new(...args:any[])=>T;
+
+/** Defines how to resize images (or other block elements). Equivalent to CSS `object-fit` property. */
+export type ResizeFitOption = "contain" | "cover" | "fill" | "scale-down" | "none";
 
 // We specifically need the CanvasRenderingContext2D and Path2D from Skia, not the default definitions, since they have methods we use which the default versions doesn't.
 // The idea is to centralize the types here which other modules need, instead of importing from skia-canvas inside each implementation.
 // This should also make is easier to change provider libraries if necessary.
 export {
-    Canvas, CanvasRenderingContext2D, CanvasRenderingContext2D as RenderContext2D,
+    Canvas, CanvasRenderingContext2D,
     DOMMatrix, DOMPoint, DOMRect,
     Image, ImageData, loadImage, loadImageData,
     Path2D, TextMetrics,
+    type CanvasTextAlign, type CanvasTextBaseline, type CanvasRenderingContext2D as RenderContext2D,
 } from 'skia-canvas';

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -9,8 +9,8 @@ export type ConstructorType<T> = new(...args:any[])=>T;
 // The idea is to centralize the types here which other modules need, instead of importing from skia-canvas inside each implementation.
 // This should also make is easier to change provider libraries if necessary.
 export {
-    Canvas, CanvasRenderingContext2D as RenderContext2D,
+    Canvas, CanvasRenderingContext2D, CanvasRenderingContext2D as RenderContext2D,
     DOMMatrix, DOMPoint, DOMRect,
-    Image, ImageData,
+    Image, ImageData, loadImage, loadImageData,
     Path2D, TextMetrics,
 } from 'skia-canvas';

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -6,4 +6,4 @@ export type TpActionDataRecord = Record<string, string>;
 // We specifically need the CanvasRenderingContext2D and Path2D from Skia, not the default definitions, since they have methods we use which the default versions doesn't.
 // The idea is to centralize the types here which other modules need, instead of importing from skia-canvas inside each implementation.
 // This should also make is easier to change provider libraries if necessary.
-export { Canvas, DOMMatrix, DOMPoint, DOMRect, Path2D, CanvasRenderingContext2D as RenderContext2D } from 'skia-canvas';
+export { Canvas, DOMMatrix, DOMPoint, DOMRect, Path2D, CanvasRenderingContext2D as RenderContext2D, TextMetrics } from 'skia-canvas';

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -1,46 +1,80 @@
 
-/** @internal */
-export type TpActionDataType = { id:string, value:string };
-/** @internal */
-export type TpActionDataArrayType = TpActionDataType[];
-/** @internal */
-export type TpActionDataRecord = Record<string, string>;
-
-/** Defines how to resize images (or other block elements). Equivalent to CSS `object-fit` property. */
-export type ResizeFitOption = "contain" | "cover" | "fill" | "scale-down" | "none";
-
-import type { CanvasGradient, CanvasPattern, CanvasTexture } from 'skia-canvas';
-export type ContextFillStrokeType = string | CanvasGradient | CanvasPattern | CanvasTexture;
-
-// We specifically need the CanvasRenderingContext2D and Path2D from Skia, not the default definitions, since they have methods we use which the default versions doesn't.
 // The idea is to centralize the types here which other modules need, instead of importing from skia-canvas inside each implementation.
 // This should also make is easier to change provider libraries if necessary.
 export {
-    Canvas, CanvasGradient, CanvasPattern, CanvasRenderingContext2D, CanvasTexture,
-    DOMMatrix, DOMPoint, DOMRect,
-    Image, ImageData, loadImage, loadImageData,
-    Path2D, TextMetrics,
-    type CanvasTextAlign, type CanvasTextBaseline, type CanvasRenderingContext2D as RenderContext2D,
+    Canvas, DOMMatrix, DOMPoint, DOMRect,
+    Image, ImageData, loadImage, loadImageData, Path2D
 } from 'skia-canvas';
 
+// Only typings from here on down.
 
-/** @internal */
-declare global {
+// for global definitions
+import type * as canvas from 'skia-canvas';
+import type * as geometry from './geometry';
+
+/** Some custom type declarations.
+    @mergeModuleWith <project>
+*/
+export declare namespace types {
+    /** All possible types for canvas fill/stroke style. */
+    type ContextFillStrokeType = string | canvas.CanvasGradient | canvas.CanvasPattern | canvas.CanvasTexture;
+    /** Defines how to resize images (or other block elements). Equivalent to CSS `object-fit` property. */
+    type ResizeFitOption = "contain" | "cover" | "fill" | "scale-down" | "none";
 
     type ConstructorType<T> = new(...args:any[])=>T;
 
-    // https://stackoverflow.com/a/49725198/3246449
-    type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
-        Pick<T, Exclude<keyof T, Keys>>  & {
-            [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
-        }[Keys];
-
     // https://stackoverflow.com/a/51365037/3246449
+    /** A recursive version of `Partial<>` type. Accepts any existing property of this object, including child objects and their properties. */
     type PartialDeep<T> = {
         [P in keyof T]?:
             T[P] extends (infer U)[] ? PartialDeep<U>[] :
             T[P] extends object | undefined ? PartialDeep<T[P]> :
             T[P];
     };
-
+    // https://stackoverflow.com/a/49725198/3246449
+    /** Requires at least one of specified properties to be present in an object. */
+    type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
+        Pick<T, Exclude<keyof T, Keys>>  & {
+            [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
+        }[Keys];
 }
+
+declare global {
+    // un-creatable skia-canvas type aliases
+    type CanvasDirection = canvas.CanvasDirection;
+    type CanvasFillRule = canvas.CanvasFillRule;
+    type CanvasFontStretch = canvas.CanvasFontStretch;
+    type CanvasGradient = canvas.CanvasGradient;
+    type CanvasLineCap = canvas.CanvasLineCap;
+    type CanvasLineJoin = canvas.CanvasLineJoin;
+    type CanvasPattern = canvas.CanvasPattern;
+    type CanvasRenderingContext2D = canvas.CanvasRenderingContext2D;
+    type CanvasTextAlign = canvas.CanvasTextAlign;
+    type CanvasTextBaseline = canvas.CanvasTextBaseline;
+    type CanvasTexture = canvas.CanvasTexture;
+    type ContextFillStrokeType = types.ContextFillStrokeType;
+    type GlobalCompositeOperation = canvas.GlobalCompositeOperation;
+    type RenderContext2D = CanvasRenderingContext2D;
+    type TextMetrics = canvas.TextMetrics;
+    type TextMetricsLine = canvas.TextMetricsLine;
+    // un-creatable geometry type aliases
+    type PointType = geometry.PointType;
+    type SizeType = geometry.SizeType;
+
+    type ResizeFitOption = types.ResizeFitOption;
+
+    // TP action data type aliases
+    type TpActionDataType = { id:string, value:string };
+    type TpActionDataArrayType = TpActionDataType[];
+    type TpActionDataRecord = Record<string, string>;
+
+    // misc utilities
+    type ConstructorType<T> = types.ConstructorType<T>;
+    type RequireAtLeastOne<T, Keys extends keyof T> = types.RequireAtLeastOne<T, Keys>;
+    type PartialDeep<T> = types.PartialDeep<T>;
+}
+
+// TODO: Update all code to rely on global declarations and remove these. Maybe declare creatable canvas/geo types as global also?
+export type RenderContext2D = canvas.CanvasRenderingContext2D;
+/** @internal */
+export type TpActionDataRecord = globalThis.TpActionDataRecord;

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -35,4 +35,12 @@ declare global {
             [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
         }[Keys];
 
+    // https://stackoverflow.com/a/51365037/3246449
+    type PartialDeep<T> = {
+        [P in keyof T]?:
+            T[P] extends (infer U)[] ? PartialDeep<U>[] :
+            T[P] extends object | undefined ? PartialDeep<T[P]> :
+            T[P];
+    };
+
 }

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -6,9 +6,6 @@ export type TpActionDataArrayType = TpActionDataType[];
 /** @internal */
 export type TpActionDataRecord = Record<string, string>;
 
-/** @internal */
-export type ConstructorType<T> = new(...args:any[])=>T;
-
 /** Defines how to resize images (or other block elements). Equivalent to CSS `object-fit` property. */
 export type ResizeFitOption = "contain" | "cover" | "fill" | "scale-down" | "none";
 
@@ -25,3 +22,17 @@ export {
     Path2D, TextMetrics,
     type CanvasTextAlign, type CanvasTextBaseline, type CanvasRenderingContext2D as RenderContext2D,
 } from 'skia-canvas';
+
+
+/** @internal */
+declare global {
+
+    type ConstructorType<T> = new(...args:any[])=>T;
+
+    // https://stackoverflow.com/a/49725198/3246449
+    type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
+        Pick<T, Exclude<keyof T, Keys>>  & {
+            [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
+        }[Keys];
+
+}

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -8,4 +8,9 @@ export type ConstructorType<T> = new(...args:any[])=>T;
 // We specifically need the CanvasRenderingContext2D and Path2D from Skia, not the default definitions, since they have methods we use which the default versions doesn't.
 // The idea is to centralize the types here which other modules need, instead of importing from skia-canvas inside each implementation.
 // This should also make is easier to change provider libraries if necessary.
-export { Canvas, DOMMatrix, DOMPoint, DOMRect, Path2D, CanvasRenderingContext2D as RenderContext2D, TextMetrics } from 'skia-canvas';
+export {
+    Canvas, CanvasRenderingContext2D as RenderContext2D,
+    DOMMatrix, DOMPoint, DOMRect,
+    Image, ImageData,
+    Path2D, TextMetrics,
+} from 'skia-canvas';

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,4 +1,4 @@
-import { PathBoolOperation, TransformOpType } from "../modules/enums";
+import { Alignment, PathBoolOperation, TransformOpType } from "../modules/enums";
 
 // Note: Const enums get replaced with actual values in the final "compiled" JS code.
 // They are _also_ exported for use in entry.tp generator (due to 'preserveConstEnums' setting in tsconfig).
@@ -100,6 +100,18 @@ export const enum SettingName {
     MaxImageProcThreads = "Maximum Image Compression Threads",
     MaxImageGenThreads = "Maximum Image Generator Threads",
 };
+
+export const ALIGNMENT_ENUM_NAMES = {
+    [Alignment.NONE]:     '',
+    [Alignment.LEFT]:     'left',
+    [Alignment.RIGHT]:    'right',
+    [Alignment.HCENTER]:  'center',
+    [Alignment.JUSTIFY]:  'justify',
+    [Alignment.TOP]:      'top',
+    [Alignment.BOTTOM]:   'bottom',
+    [Alignment.VCENTER]:  'middle',
+    [Alignment.BASELINE]: 'baseline',
+} as const;
 
 // Math constants
 export const enum M {

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -65,18 +65,27 @@ export const enum ChoiceDataId {
 
 // Strings for misc. data values where the UI and processing code must match.
 export const enum DataValue {
+    // Choices for ControlCommand action
     ClearImageCache = "Clear the Source Image Cache",
     DelIconState = "Delete Icon State",
+    // Mapped to ClippingMask.ClipAction enum types
     ClipMaskNormal  = "Create Normal",
     ClipMaskInverse = "Create Inverse",
     ClipMaskRelease = "Release",
+    // Mapped to ColorUpdateType enum types
     ColorTypeStroke = "Stroke/Foreground",
     ColorTypeFill   = "Fill/Background",
     ColorTypeShadow = "Shadow",
+    // Mapped to Transformation.TransformScope enum types
     TxScopePreviousOne = "previous layer",
     TxScopeCumulative  = "all previous",
     TxScopeUntilReset  = "all following",
     TxScopeReset       = "reset following",
+    // Mapped to ArcDrawDirection enum types
+    ArcDrawCW          = "Clockwise",
+    ArcDrawCCW         = "Counter CW",
+    ArcDrawAuto        = "Automatic",
+    // Yes/No options on various actions
     YesValue           = "Yes",
     NoValue            = "No",
 }
@@ -101,7 +110,7 @@ export const enum M {
     R2D = 180 / PI,
 }
 
-
+// The exports not used in the core source code are for the entry.tp generator script.
 export const CTRL_CMD_ACTION_CHOICES = [ DataValue.ClearImageCache, DataValue.DelIconState ];
 export const DEFAULT_TRANSFORM_OP_ORDER = [TransformOpType.Offset, TransformOpType.Rotate, TransformOpType.Scale, TransformOpType.Skew];
 export const STYLE_FILL_RULE_CHOICES = ["nonzero", "evenodd"];
@@ -110,4 +119,4 @@ export const PATH_BOOL_OPERATION_CHOICES = [
     PathBoolOperation.Difference, PathBoolOperation.Intersect, PathBoolOperation.Union, PathBoolOperation.Xor
 ];
 export const COLOR_UPDATE_TYPE_CHOICES = [DataValue.ColorTypeStroke, DataValue.ColorTypeFill, DataValue.ColorTypeShadow];
-
+export const ARC_DIRECTION_CHOICES = [ DataValue.ArcDrawCW, DataValue.ArcDrawCCW, DataValue.ArcDrawAuto ]

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -86,6 +86,7 @@ export const enum SettingName {
     ImageFilesPath = "Default Image Files Path",
     GPU = "Use GPU Rendering by Default",
     PngCompressLevel = "Default Output Image Compression Level (0-9)",
+    PngQualityLevel = "Default Output Image Quality (1-100)",
     MaxImageProcThreads = "Maximum Image Compression Threads",
     MaxImageGenThreads = "Maximum Image Generator Threads",
 };

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -36,6 +36,8 @@ export const enum Act {
     IconProgGauge = "progGauge",
     IconProgBar = "progBar",
     IconBarGraph = "barGraph",
+    IconCircularTicks = "circularTicks",
+    IconLinearTicks = "linearTicks",
     IconRect = "rect",
     IconText = "text",
     IconImage = "image",
@@ -88,6 +90,14 @@ export const enum DataValue {
     // Yes/No options on various actions
     YesValue           = "Yes",
     NoValue            = "No",
+    // Mapped to Placement enum types
+    PlaceInside        = "Inside",
+    PlaceOutside       = "Outside",
+    PlaceInward        = "Inward",
+    PlaceOutward       = "Outward",
+    PlaceTopLeft       = "Top/Left",
+    PlaceBotRight      = "Bottom/Right",
+    PlaceCenter        = "Center",
 }
 
 // Full names of plugin settings used in TP UI and messages.

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -32,6 +32,7 @@ export const enum Act {
     ControlCommand = "command",
     IconDeclare = "declare",
     IconGenerate = "generate",
+    IconSaveFile = "saveFile",
     IconProgGauge = "progGauge",
     IconProgBar = "progBar",
     IconBarGraph = "barGraph",

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -88,9 +88,11 @@ export const enum DataValue {
     ArcDrawCW          = "Clockwise",
     ArcDrawCCW         = "Counter CW",
     ArcDrawAuto        = "Automatic",
-    // Yes/No options on various actions
+    // Boolean options on various actions
     YesValue           = "Yes",
     NoValue            = "No",
+    OnValue            = "On",
+    OffValue           = "Off",
     // Mapped to Placement enum types
     PlaceInside        = "Inside",
     PlaceOutside       = "Outside",

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -82,7 +82,7 @@ export const enum DataValue {
 export const enum SettingName {
     IconSize = "Default Icon Size",
     ImageFilesPath = "Default Image Files Path",
-    GPU = "Enable GPU Rendering by Default",  // unused for now
+    GPU = "Use GPU Rendering by Default",
     PngCompressLevel = "Default Output Image Compression Level (0-9)",
     MaxImageProcThreads = "Maximum Image Compression Threads",
 };

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -76,6 +76,8 @@ export const enum DataValue {
     TxScopeCumulative  = "all previous",
     TxScopeUntilReset  = "all following",
     TxScopeReset       = "reset following",
+    YesValue           = "Yes",
+    NoValue            = "No",
 }
 
 // Full names of plugin settings used in TP UI and messages.

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -41,6 +41,7 @@ export const enum Act {
     IconRect = "rect",
     IconText = "text",
     IconImage = "image",
+    IconScript = "script",
     IconFilter = "filter",
     IconCompMode = "compMode",
     IconTx = "tx",

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -85,6 +85,7 @@ export const enum SettingName {
     GPU = "Use GPU Rendering by Default",
     PngCompressLevel = "Default Output Image Compression Level (0-9)",
     MaxImageProcThreads = "Maximum Image Compression Threads",
+    MaxImageGenThreads = "Maximum Image Generator Threads",
 };
 
 // Math constants

--- a/src/utils/drawing.ts
+++ b/src/utils/drawing.ts
@@ -1,0 +1,251 @@
+
+import { M, normalizeAngle, round4p } from './';
+import { DOMMatrix, Path2D, Rectangle } from '../modules';
+import type { PointType, RenderContext2D, SizeType } from '../modules';
+
+/**
+Returns a Path2D object containing a full or partial circle of tick marks, like a compass or speedometer.
+Each segment of the resulting path consists of a separate line for each "tick."
+@param x Horizontal center coordinate
+@param y Vertical center coordinate
+@param rx Horizontal radius in pixels
+@param ry Vertical radius in pixels
+@param from Degrees to start from; 0° points north. Can be negative.
+@param to Degrees to end at (eg. 0, 360 to draw a full circle, 0, 180 for half circle, etc). 0° points north. Can be negative.
+@param count Number of tick marks to draw; First tick is drawn at start position (`from`) and the rest are spread out evenly between start and end angles.
+@param len Length of tick marks. Negative value draws a line (tick mark) of that length from outer point towards center of circle. Positive values draw outward.
+    Length can also be an array of lengths, in which case it will use the line lengths from array for each consecutive line, modulo the array's length.
+    eg. drawing any even number of ticks with alternating sizes: `l = [10, 5]`
+    A line length of zero in the array can be used to skip drawing a tick at that position.
+@param ctr Set to `true` to center the tick marks along the circumference, dividing the given length(s) by 2 so that half the tick points to the outside and half to the inside.
+*/
+export function cirularGaugeTicksPath(x: number, y: number, rx: number, ry: number, from: number, to: number, count: number, len: number|Array<number>, ctr = false): Path2D
+{
+    // const lines: Array<PointType[]> = [];
+    const p = new Path2D(),
+        n = round4p((to - from) / (count - (!normalizeAngle(to - from) ? 0 : 1)));
+    // console.log({x,y,rx,ry,from, to, count, n})
+    from -= 90;
+    // p.ellipse(x, y, rx, ry, 0, from * M.D2R, (to - 90) * M.D2R, false);  // debug baseline path
+    if (!Array.isArray(len))
+        len = [len];
+    let i=0, a = from,
+        px: number, py: number, lx: number, ly: number,
+        ar: number, c: number, s: number, ll: number;
+    for (; i < count; a += n, ++i) {
+        ll = len[i % len.length]
+        if (!ll)
+            continue;
+        ar = a * M.D2R;
+        c = Math.cos(ar);
+        s = Math.sin(ar);
+        if (ctr) {
+            ll = Math.abs(ll) * .5;
+            px = round4p(x + (rx - ll) * c);
+            py = round4p(y + (ry - ll) * s);
+        }
+        else if (ll > 0) {
+            px = round4p(x + (rx + ll) * c);
+            py = round4p(y + (ry + ll) * s);
+            ll = 0;
+        }
+        else {
+            px = round4p(x + rx * c);
+            py = round4p(y + ry * s);
+        }
+        lx = round4p(x + (rx + ll) * c);
+        ly = round4p(y + (ry + ll) * s);
+        p.moveTo(px, py);
+        p.lineTo(lx, ly);
+        // lines.push([{x: px, y: py}, {x:lx, y:ly}]);
+    }
+    return p;
+    // return lines;
+}
+
+/**
+Returns a Path2D object containing a full or partial circle of labels, like the markings for a compass or speedometer.
+@param ctx An instance of CanvasRenderContext2D to use for creation of paths for individual labels. It should already have all desired typography properties applied (font, etc).
+@param x Horizontal center coordinate
+@param y Vertical center coordinate
+@param rx Horizontal radius in pixels
+@param ry Vertical radius in pixels
+@param from Degrees to start from; 0° points north. Can be negative.
+@param to Degrees to end at (eg. 0, 360 to draw a full circle, 0, 180 for half circle, etc). 0° points north. Can be negative.
+@param labels The array of label strings to use; First label is drawn at start position (`from`), and the rest are spread out evenly between start and end angles.
+@param position Set to `-1` to position the labels towards the inside of the arc, or `1` towards the outside.
+@param rotate Degrees of rotation to apply to labels. If `rotateToAngle` == 0 then the angle is an offset from horizontal, otherwise it is the offset from the rotated label angle.
+@param rotateToAngle Set to `1` to rotate the labels so they face inward towards the center of the arc, `-1` to rotate so they face away from center, or `0` (default) to keep the labels horizontal.
+*/
+export function circularLabelsPath(ctx: RenderContext2D, x: number, y: number, rx: number, ry: number, from: number, to: number, labels: Array<string>, position: 1|-1, rotate = 0, rotateToAngle = 0)
+{
+    const p = new Path2D(),
+        count = labels.length,
+        n = round4p((to - from) / (count - (!normalizeAngle(to - from) ? 0 : 1)));
+    // console.log({x,y,rx,ry,from,to,position,rotate,angled,n});
+    from -= 90;
+    rotate += 90 * rotateToAngle;
+    let i = 0, a = from,
+        c: number, s: number, ar: number, tX: number, tY: number, d: number,
+        str: string, lbl: Path2D, bounds: Rectangle, pt: PointType;
+    for (; i < count; a += n, ++i) {
+        str = labels[i];
+        if (!str)
+            continue;
+        lbl = ctx.outlineText(str);
+        bounds = Rectangle.fromBounds(lbl.bounds);
+        // translate label path so bounds rectangle center point is always at 0,0
+        pt = bounds.center;
+        lbl = lbl.offset(-pt.x, -pt.y);
+        // bounds.translate(-pt.x, -pt.y);
+        // figure out offset for final label position
+        ar = a * M.D2R;
+        c = Math.cos(ar);
+        s = Math.sin(ar);
+        if (rotate) {
+            // if text is rotated then we need to offset by a common delta value based on the Y axis offset
+            pt = vectorToEdge(bounds.size, rotate * M.D2R);
+            d = Math.abs(pt.y) * position;
+            tX = round4p(x + (rx + d) * c);
+            tY = round4p(y + (ry + d) * s);
+            // console.log(str, {a, d, tX, tY}, '\n', b.toString());
+            p.addPath(lbl.transform(new DOMMatrix([1, 0, 0, 1, tX, tY]).rotateZSelf(rotate + (rotateToAngle ? a : 0))));
+        }
+        else {
+            // For horizontal labels, figure out offset based on vector from center of label bounds to closest edge at current drawing angle;
+            // The angle to use depends on label's `position` -- if drawing towards inside (position == -1) then we need the opposite of current angle.
+            pt = vectorToEdge(bounds.size, (position < 0 ? ar : ar - M.PI), c * -position, s * -position);
+            tX = round4p(x + rx * c - pt.x);
+            tY = round4p(y + ry * s - pt.y);
+            // console.log(str, v, {a, ba:(position < 0 ? ar : ar - M.PI) * M.R2D, c, s, tX, tY}, '\n', b.toString());
+            p.addPath(lbl.offset(tX, tY));
+        }
+    }
+    return p;
+}
+
+/**
+Returns a Path2D object containing tick marks arranged along a straight line, like on a linear thermometer.
+Each segment of the resulting path consists of a separate line for each "tick."
+@param x Horizontal starting coordinate
+@param y Vertical starting coordinate
+@param size Total length of path for ticks. The ticks will be spaced to fit within this size.
+@param vertical The line will be drawn vertically if `true`, horizontally otherwise.
+@param count Number of tick marks to draw; These will be spaced out evenly between the relevant starting coordinate and the given `size`.
+@param len Length of tick marks. Negative value draws a tick mark of that length from the line towards top/left. Positive values draw towards bottom/right.
+    Length can also be an array of lengths, in which case it will use the line lengths from array for each consecutive line, modulo the array's length.
+    eg. drawing any even number of ticks with alternating sizes: `l = [10, 5]`
+    A line length of zero in the array can be used to skip drawing a tick at that position.
+@param ctr Set to `true` to center the tick marks along the line, dividing the given length(s) by 2 so that half the tick points to the top/left and half to the bottom/right.
+*/
+export function linearGaugeTicksPath(x: number, y: number, size: number, vertical: boolean, count: number, len: number|Array<number>, ctr = false): Path2D
+{
+    const p = new Path2D(),
+        n = round4p(size / (count - 1));
+    if (!Array.isArray(len))
+        len = [len];
+    let pos = vertical ? y : x, i = 0, ll: number;
+    for (; i < count; ++i, pos += n) {
+        ll = len[i % len.length]
+        if (!ll)
+            continue;
+        if (ctr) {
+            ll = round4p(Math.abs(ll) * .5);
+            vertical ? p.moveTo(x - ll, pos) : p.moveTo(pos, y - ll);
+        }
+        else {
+            vertical ? p.moveTo(x, pos) : p.moveTo(pos, y);
+        }
+        vertical ? p.lineTo(x + ll, pos) : p.lineTo(pos, y + ll);
+    }
+    return p;
+}
+
+/**
+Returns a Path2D object containing text labels arranged along a straight line, like the markings on a linear thermometer.
+@param ctx An instance of CanvasRenderContext2D to use for creation of paths for individual labels. It should already have all desired typography properties applied (font, etc).
+@param x Horizontal starting coordinate
+@param y Vertical starting coordinate
+@param size Total length of path for labels. The labels will be spaced to fit within this size.
+@param vertical The line of labels will be drawn vertically if `true`, horizontally otherwise.
+@param labels The array of label strings to use; These will be spaced out evenly between the relevant starting coordinate and the given `size`.
+@param position Set to `-1` to position the labels towards the top/left of the line, or `1` towards the bottom/right.
+@param rotate Degrees of rotation to apply to labels.
+@param alignAuto `true` will automatically align the text based on line position and orientation. If `false`, assumes horizontal text alignment has already been set as desired.
+*/
+export function linearLabelsPath(ctx: RenderContext2D, x: number, y: number, size: number, vertical: boolean, labels: Array<string>, position: 1|-1, rotate = 0, alignAuto = true): Path2D
+{
+    const p = new Path2D(),
+        count = labels.length,
+        n = round4p(size / (count - 1)),
+        angleToLbl = rotate ? ((vertical ? (position < 0 ? -M.PI : 0) : M.PI_2 * -position) + -rotate * M.D2R) : 0,
+        atlCos = Math.cos(angleToLbl),
+        atlSin = Math.sin(angleToLbl);
+    // console.log({ x, y, size, vertical, position, rotate, alignAuto, ctxAlign: ctx.textAlign, angleToLbl: angleToLbl * M.R2D });
+    let pos = vertical ? y : x, i = 0,
+        tX: number, tY: number, d: number,
+        lbl: Path2D, str: string, bounds: Rectangle, pt: PointType;
+    for (; i < count; ++i, pos += n) {
+        str = labels[i];
+        if (!str)
+            continue;
+
+        lbl = ctx.outlineText(str);
+        bounds = Rectangle.fromBounds(lbl.bounds);
+        // translate label path so it is centered on Y axis, and on X axis if auto-aligning
+        pt = bounds.center;
+        if (!alignAuto)
+            pt.x = 0;
+        lbl = lbl.offset(-pt.x, -pt.y);
+        // bounds.translate(-pt.x, -pt.y);
+        // console.log(str, {pt, }, '\n  '+bounds.toString());
+
+        if (rotate) {
+            pt = vectorToEdge(bounds.size, angleToLbl, atlCos, atlSin);
+            d = Math.abs(vertical ? pt.x : pt.y) * position;
+            // console.log(str, {pt, d});
+        }
+        else if (alignAuto) {
+            d = round4p((vertical ? bounds.width : bounds.height) * .5) * position;
+        }
+        else {
+            d = 0;
+        }
+
+        if (vertical) {
+            tX = x + d;
+            tY = pos;
+        }
+        else {
+            tX = pos;
+            tY = y + d;
+        }
+        // console.log(pos, tX, tY, str, lbl.bounds);
+        if (rotate)
+            p.addPath(lbl.transform(new DOMMatrix([1, 0, 0, 1, tX, tY]).rotateZSelf(rotate)));
+        else
+            p.addPath(lbl.offset(tX, tY));
+    }
+    return p;
+}
+
+// Returns x,y coordinates from center of given size bounds to the closest edge at given angle;
+// pass cosine and sine of angle if already known
+function vectorToEdge(bounds: SizeType, radians: number, c?: number, s?: number) {
+    if (c == undefined || s == undefined) {
+        c = Math.cos(radians);
+        s = Math.sin(radians);
+    }
+
+    let x: number, y: number;
+    if (bounds.width * Math.abs(s) < bounds.height * Math.abs(c)) {
+        x = Math.sign(c) * bounds.width * .5;
+        y = Math.tan(radians) * x;
+    }
+    else {
+        y = Math.sign(s) * bounds.height * .5;
+        x = (1 / Math.tan(radians)) * y;
+    }
+    return { x:round4p(x), y:round4p(y) };
+}
+

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -1,0 +1,110 @@
+
+const { CanvasRenderingContext2D } = require('skia-canvas');  // for some reason get a "CanvasRenderingContext2D is not defined" error if using "import" instead
+import { DOMMatrix } from 'skia-canvas';
+import { M } from './consts';
+import type { PointType, CanvasRenderingContext2D } from '../modules';
+
+// Extends `DOMMatrix` and `CanvasRenderingContext2D` with `rotate*()` method
+// overloads which accept an optional origin point around which to rotate.
+// Also adds `CanvasRenderingContext2D.scale(x, y, origin)` overload.
+// Adds more efficient `DOMMatrix.rotateZ[Self]()` methods which skip a couple useless multiplication steps of the original.
+
+declare module 'skia-canvas' {
+
+    export interface CanvasTransform {
+        rotate(radians: number, origin?: PointType): void;
+        rotate(radians: number, origin?: [number,number]): void;
+        rotate(radians: number, originX?: number, originY?: number): void;
+
+        scale(x: number, y: number, origin?: PointType): void;
+        scale(x: number, y: number, origin?: [number,number]): void;
+        scale(x: number, y: number, originX?: number, originY?: number): void;
+    }
+
+    export interface DOMMatrix {
+        rotate(degX?: number, degY?: number, degZ?: number, origin?: PointType): DOMMatrix;
+        rotate(degX?: number, degY?: number, degZ?: number, origin?: [number,number]): DOMMatrix;
+        rotate(degX?: number, degY?: number, degZ?: number, originX?: number, originY?: number): DOMMatrix;
+        rotateSelf(degX?: number, degY?: number, degZ?: number, origin?: PointType): DOMMatrix;
+        rotateSelf(degX?: number, degY?: number, degZ?: number, origin?: [number,number]): DOMMatrix;
+        rotateSelf(degX?: number, degY?: number, degZ?: number, originX?: number, originY?: number): DOMMatrix;
+
+        rotateZ(degrees: number, origin?: PointType): DOMMatrix;
+        rotateZ(degrees: number, origin?: [number,number]): DOMMatrix;
+        rotateZ(degrees: number, originX?: number, originY?: number): DOMMatrix;
+        rotateZSelf(degrees: number, origin?: PointType): DOMMatrix;
+        rotateZSelf(degrees: number, origin?: [number,number]): DOMMatrix;
+        rotateZSelf(degrees: number, originX?: number, originY?: number): DOMMatrix;
+    }
+
+}
+
+type Origin = PointType | [number,number] | number;
+
+const txOriginFromArgs = function(origin?: Origin, originY?: number): [number,number] {
+    return Array.isArray(origin) ? origin : typeof origin == 'object' ? [origin.x, origin. y] : [origin ?? 0, originY ?? 0];
+}
+
+const NATIVE_METHODS = {
+    contextRotate: CanvasRenderingContext2D.prototype.rotate,
+    contextScale: CanvasRenderingContext2D.prototype.scale,
+    matrixRotateSelf: DOMMatrix.prototype.rotateSelf,
+} as const;
+
+// export function extendCanvasContext() {
+    CanvasRenderingContext2D.prototype.rotate = function(this: CanvasRenderingContext2D, radians: number, origin?: Origin, originY?: number) {
+        if (!origin && !originY)
+            return NATIVE_METHODS.contextRotate.call(this, radians);
+        const [tx,ty] = txOriginFromArgs(origin, originY);
+        this.translate(tx, ty);
+        NATIVE_METHODS.contextRotate.call(this, radians);
+        this.translate(-tx, -ty);
+    }
+    CanvasRenderingContext2D.prototype.scale = function(this: CanvasRenderingContext2D, x: number, y: number, origin?: Origin, originY?: number) {
+        if (!origin && !originY)
+            return NATIVE_METHODS.contextScale.call(this, x, y);
+        const [tx, ty] = txOriginFromArgs(origin, originY);
+        this.translate(tx, ty);
+        NATIVE_METHODS.contextScale.call(this, x, y);
+        this.translate(-tx, -ty);
+    }
+// }
+
+
+// export function extendDOMMatrix() {
+    DOMMatrix.prototype.rotateSelf = function(this: DOMMatrix, degX?: number, degY?: number, degZ?: number, origin?: Origin, originY?: number): DOMMatrix {
+        if (arguments.length == 1)
+            return this.rotateZSelf(degX!);
+        if (arguments.length <= 3)
+            return NATIVE_METHODS.matrixRotateSelf.call(this, degX, degY, degZ);
+        if (!degX && !degY)
+            return this.rotateZSelf(degZ!, <number>origin, originY);
+
+        const [tx,ty] = txOriginFromArgs(origin, originY);
+        this.translateSelf(tx, ty);
+        NATIVE_METHODS.matrixRotateSelf.call(this, degX, degY, degZ);
+        return this.translateSelf(-tx, -ty);
+    }
+
+    // A more efficient 2D rotation with only 1 multiplication step vs. 3 of the original.
+    DOMMatrix.prototype.rotateZSelf = function(this: DOMMatrix, angle: number, origin?: Origin, originY?: number): DOMMatrix {
+        angle *= M.D2R;
+        const c = Math.cos(angle),
+            s = Math.sin(angle),
+            m = new DOMMatrix([c, s, 0, 0, -s, c, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+        if (!origin && !originY)
+            return this.multiplySelf(m);
+
+        const [tx,ty] = txOriginFromArgs(origin, originY);
+        this.translateSelf(tx, ty);
+        this.multiplySelf(m);
+        return this.translateSelf(-tx, -ty);
+    }
+
+    DOMMatrix.prototype.rotate = function(this: DOMMatrix, degX?: number, degY?: number, degZ?: number, origin?: Origin, originY?: number): DOMMatrix {
+        return this.clone().rotateSelf(degX, degY, degZ, <number>origin, originY);
+    }
+    DOMMatrix.prototype.rotateZ = function(this: DOMMatrix, degrees: number, origin?: Origin, originY?: number): DOMMatrix {
+        return this.clone().rotateZSelf(degrees, <number>origin, originY);
+    }
+// }

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -2,7 +2,6 @@
 const { CanvasRenderingContext2D } = require('skia-canvas');  // for some reason get a "CanvasRenderingContext2D is not defined" error if using "import" instead
 import { DOMMatrix } from 'skia-canvas';
 import { M } from './consts';
-import type { PointType, CanvasRenderingContext2D } from '../modules';
 
 // Extends `DOMMatrix` and `CanvasRenderingContext2D` with `rotate*()` method
 // overloads which accept an optional origin point around which to rotate.

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,7 @@
 import { Str } from './consts'
 import { Alignment, logging, PointType } from '../modules';
+import { PluginSettings } from '../common';
+import { isAbsolute as pathIsAbs, join as pathJoin } from 'path';
 
 // Used to validate if a string is a single numeric value. Accepts leading sign, base prefix (0x/0b/0o), decimals, and exponential notation.
 const NUMBER_VALIDATION_REGEX = new RegExp(/^[+-]?(?:0[xbo])?\d+(?:\.\d*)?(?:e[+-]?\d+)?$/);
@@ -58,6 +60,11 @@ export function elideRight(str: string, maxLen: number): string {
     return str.slice(0, maxLen+1) + "…";
 }
 
+export function qualifyFilepath(path: string): string {
+    if (PluginSettings.imageFilesBasePath && !pathIsAbs(path))
+        return pathJoin(PluginSettings.imageFilesBasePath, path);
+    return path;
+}
 
 // ------------------------
 // Object helpers

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -77,13 +77,15 @@ export function qualifyFilepath(path: string): string {
 
 /** Assigns property values in `from` object to values in the `to` object, but _only_ if they already exist in `to` _and_ have a matching `typeof` type.
     Recurses up to `recurseLevel` nested objects, and skips assigning object-type properties beyond the recursion level. Arrays are copied by value.
+    If `strToNum` is `true` then source string types are considered compatible with destination numeric types (destination is responsible for conversion).
 */
-export function assignExistingProperties(to: {}, from?: {}, recurseLevel = 0) {
+export function assignExistingProperties(to: {}, from?: {}, recurseLevel = 0, strToNum = false) {
     if (!to || !from)
         return;
     for (const key in from) {
-        if (key in to && typeof to[key] == typeof from[key]) {
-            if (typeof to[key] == 'object' && !Array.isArray(to[key])) {
+        const toType = typeof to[key], fromType = typeof from[key];
+        if (key in to && (toType == fromType || (strToNum && toType == 'number' && fromType == 'string'))) {
+            if (toType == 'object' && !Array.isArray(to[key])) {
                 if (recurseLevel > 0)
                     assignExistingProperties(to[key], from[key], recurseLevel - 1);
             }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { Str } from './consts'
-import { Alignment, logging, PointType } from '../modules';
+import { Alignment, logging, PointType, ArcDrawDirection } from '../modules';
 import { PluginSettings } from '../common';
 import { isAbsolute as pathIsAbs, join as pathJoin } from 'path';
 
@@ -251,6 +251,21 @@ export function parseAlignmentsFromString(value: string, mask: Alignment = (Alig
     for (const v of values)
         ret |= parseAlignmentFromValue(v, mask);
     return ret;
+}
+
+/** Parses a string into an `ArcDrawDirection` enum value. If no match is found then `defaultValue` is returned.
+    Strings must match one of: "Clockwise", "Counter CW", or "Automatic" (case-insensitive). */
+export function parseArcDirection(value: string, defaultValue: ArcDrawDirection = ArcDrawDirection.CW): ArcDrawDirection {
+    switch (value[1]) {
+        case 'l':
+            return ArcDrawDirection.CW;
+        case 'o':
+            return ArcDrawDirection.CCW;
+        case 'u':
+            return ArcDrawDirection.Auto;
+        default:
+            return defaultValue;
+    }
 }
 
 /** Returns true/false based on if a string value looks "truthy", meaning it contains "yes", "on", "true", "enable[d]", or any digit > 0. */

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { Str } from './consts'
-import { Alignment, logging, PointType, ArcDrawDirection } from '../modules';
+import { Alignment, logging, Placement, PointType, ArcDrawDirection } from '../modules';
 import { PluginSettings } from '../common';
 import { isAbsolute as pathIsAbs, join as pathJoin } from 'path';
 
@@ -42,6 +42,12 @@ export function fuzzyEquals5p(value1: number, value2: number): boolean { return 
 /** Returns true if 2 numbers are equal within 6 decimal places of precision. */
 export function fuzzyEquals6p(value1: number, value2: number): boolean { return fuzzyEquals(value1, value2, 0.000_001); }
 
+export function normalizeAngle(degrees: number): number {
+    degrees %= 360;
+    if (degrees < 0)
+        return degrees + 360;
+    return degrees;
+}
 
 // ------------------------
 // String utils.
@@ -265,6 +271,20 @@ export function parseArcDirection(value: string, defaultValue: ArcDrawDirection 
             return ArcDrawDirection.Auto;
         default:
             return defaultValue;
+    }
+}
+
+export function parsePlacement(v: string, defaultValue: Placement = Placement.NoPlace): Placement {
+    if (!v)
+        return defaultValue;
+    // possible values: "Inside" | "Top/Left", "Outside" | "Bottom/Right", "Center", "Same as ..."
+    switch (v[0].toUpperCase()) {
+        case 'I': return Placement.Inside;
+        case 'O': return Placement.Outside;
+        case 'C': return Placement.Center;
+        case 'T': return Placement.TopLeft;
+        case 'B': return Placement.BottomRight;
+        default: return defaultValue;
     }
 }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -108,14 +108,14 @@ export function evaluateValue(value: string, defaultValue: number | any = 0): nu
         // because they'll return any number at the start of a string and ignore the rest (eg from "2 + 2" they return 2).
         // Use Number() c'tor vs. parseFloat() because it also handles base prefixes (0x/0b/0o).
         if (NUMBER_VALIDATION_REGEX.test(value))
-            return Number(value) || defaultValue;
+            return Number(value) ?? defaultValue;
 
         // If it's not just a plain number then evaluate it as an expression.
-        return (new Function( `"use strict"; return (${value})`))() || defaultValue;
+        return (new Function( `"use strict"; return (${value})`))() ?? defaultValue;
     }
     catch (e) {
-        logging().getLogger('plugin').warn("Error evaluating the numeric expression '" + value + "':", e)
-        return 0
+        logging().getLogger('plugin').warn("Error evaluating the numeric expression '" + value + "':", e);
+        return defaultValue;
     }
 }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -40,6 +40,25 @@ export function fuzzyEquals5p(value1: number, value2: number): boolean { return 
 /** Returns true if 2 numbers are equal within 6 decimal places of precision. */
 export function fuzzyEquals6p(value1: number, value2: number): boolean { return fuzzyEquals(value1, value2, 0.000_001); }
 
+
+// ------------------------
+// String utils.
+
+/** Left-trims `str` to `maxLen` characters and adds an ellipsis at the start if the input string was shortened. */
+export function elideLeft(str: string, maxLen: number): string {
+    if (str.length <= maxLen)
+        return str;
+    return "…" + str.slice(-maxLen);
+}
+
+/** Right-trims `str` to `maxLen` characters and adds an ellipsis to the end if the input string was shortened. */
+export function elideRight(str: string, maxLen: number): string {
+    if (str.length <= maxLen)
+        return str;
+    return str.slice(0, maxLen+1) + "…";
+}
+
+
 // ------------------------
 // Object helpers
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './consts'
+export * from './drawing'
 export * from './helpers'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './consts'
 export * from './helpers'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     ], /* List of folders to include type definitions from. */
     "allowSyntheticDefaultImports": true, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "alwaysStrict": true,
-    "declaration": true,
-    "declarationMap": true,
+    "declaration": false,
+    "declarationMap": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2022"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "typeRoots": [
-      "./src/typings/*",
       "./node_modules/@types"
     ], /* List of folders to include type definitions from. */
     "allowSyntheticDefaultImports": true, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
@@ -10,6 +9,7 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "lib": ["es2022"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
### New Features
- Added "Circular Tick Marks" and "Linear Tick Marks" actions for drawing gauge "ticks" and/or labels with multiple options (TP v4+ only).
- Added "Run Custom Script" action to run user-provided JavaScript code with access to current Canvas context for custom drawing (see [Custom Scripts] wiki page for details).
- Added "Save Icon to File" action to export generated images to files in various formats. This can be found in the "Layer Actions" group.
  - Available export formats: AVIF, GIF, JPEG, PNG, TIFF, & WebP.
  - Each export format has various options (such as compression level, quality, etc) that can be specified in a "option=value, ..." list and have been documented in the wiki: [File Output Options].
- Added `vw`, `vh`, `vmin` & `vmax` relative size unit types for use in font sizing and other CSS-like properties. These correspond to the [standard CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh) versions and represent 1 percent of the current icon size ("viewport") width & height, or minium/maximum of the width or height, respectively. E.g. `5vh` is 5% of the icon height, or `5vmin` is 5% of the smaller of icon width or height.
- Added new "Wrap Width" option to "Draw - Text" action which will automatically wrap long text to the specified width if it won't fit on one line.
- Added option to control color quality (number of colors) of generated images to help further reduce image data size. Default value is available as a new plugin setting and the quality can also be set per layered icon in the "Generate" action.
- Added new plugin setting to control the maximum number of threads used by `skia-canvas` for drawing images.

### Changes
- SVG images are now kept as scalable vector graphics instead of being rasterized at a fixed size during initial loading. This prevents any pixelation due to scaling, including when manipulating the image with transformations. However, it comes with some caveats:
  - The new SVG parser is more strict about syntax and may fail to load some documents. In such cases the plugin will fall back to using the previous method of loading SVGs to raster images.
    If your SVGs appear pixelated, check the plugin's log file for warnings about this, and validate/simplify your SVG syntax if you find loading errors.
  - The new parser may also log warnings about element(s) it doesn't "like" but which don't prevent loading the image. These will show up in the TP log since unfortunately there's no way for us
    to intercept them. If you see messages like "cannot append child nodes to an SVG shape" being logged, ignore them or check your SVGs.
- "Draw - Text" action now properly supports `serif`, `sans-serif`, `monospace`, and `system-ui` generic font families. Existing icons which were using generic font names will likely change as a result.
- Replaced "Tracking" option with "Letter Spacing" on "Draw - Text" action.
- Improved text rendering and alignment (may have slight alignment differences with some fonts vs. previous version).
- Converted the layer "position" field in all "Animate & Update" actions to "text" type which allows TP variables to be used.
- Added "Auto" as a choice for "Draw Direction" setting in "Paths - Add Ellipse / Arc" action. This automatically draws in the counterclockwise direction if the specified ending angle value is lower than the starting angle.
- A message is now written to the log file whenever deleting an icon instance.
- Moved the plugin's actions to Touch Portal "Tools" category.

### Fixes
- Improved stability with multi-layered images to ensure elements are applied in the correct order, especially when using elements like complex paths or generating many images at once.
  In some (rare) cases the actions could not be parsed in time before the next action's data came in, leading to elements being assigned to the wrong layers.
- Fixed rendering issues with some combinations of drop-shadow effects and rotation transformations (upstream in `skia-canvas`).
- Fixed clearing the image cache for an icon instance which shares the cached image with other icon instances but wasn't the first to use that image.
- Fixed skew transformation not working properly except with very large values (wasn't scaled correctly).
- Fixed that "Simple Bar Graph" used as a standalone (non-layered) icon didn't respect the default icon size from plugin settings when calculating how many bars can fit on one image.
- Fixed that "small-caps" font variant was not being respected in the "Draw - Text" action font specification.

### Other Updates
- Updated `skia-canvas` drawing library to v2.0.2 (includes all related upstream libraries and the underlying _Skia Graphics_ itself).
- Updated `sharp` image loading and compression library to v0.33.5.
- Releases now use NodeJS v22 (LTS) runtime, up from v18.
- Added separate release builds for MacOS Intel (x64) and ARM64 (Mn) architectures.


[File Output Options]: https://github.com/spdermn02/TouchPortal-Dynamic-Icons/wiki/File-Output-Options
[Custom Scripts]: https://github.com/spdermn02/TouchPortal-Dynamic-Icons/wiki/Custom-Scripts

#### New action screenshots

Circular Tick Marks:

![image](https://github.com/user-attachments/assets/f584f883-a1b9-45f4-83f8-5c3b15e8233e)

Linear Tick Marks:

![image](https://github.com/user-attachments/assets/a6ed5dee-3cc3-4bcd-9bbd-e5ed531a2131)

Run Custom Script:

![image](https://github.com/user-attachments/assets/60207fa6-274f-4852-8143-f93d2b41e106)

Save To File:

![image](https://github.com/user-attachments/assets/76729c3d-9d62-40fc-9f98-7e773cdc64f5)


#### Gauge Ticks examples

Just some I was using to test with

![image](https://github.com/user-attachments/assets/c0fdcc49-acc0-4d8d-9524-3525a6e9e6db)
![image](https://github.com/user-attachments/assets/76d93f65-7321-4548-a284-f1fd63204a22)
![image](https://github.com/user-attachments/assets/f66523d5-eb20-422d-9375-06b73f777acf)

